### PR TITLE
refactor: address review feedback for soundness, correctness, and API hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 ~
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (review-driven)
+
+- **#1** Replaced all `unsafe impl Send/Sync` (`RegistryClient`, `Registry`, `Decompress`, `Reader`) with sound trait-bound types backed by `Arc<dyn ... + Send + Sync>` and `Pin<Box<dyn AsyncRead + Send + Sync>>`.
+- **#2** Introduced `Digest` newtype (`src/digest.rs`) that validates `algo:hex`; replaced every digest `unwrap()` / `strip_prefix("sha256:").unwrap()` with `Digest::parse(...)?`.
+- **#3** `Token::parse` and ECR base64 decoding now return typed `InvalidAuth` errors instead of panicking on malformed config.
+- **#4** Replaced `join_all` with `try_join_all` in `Image::to_tarball`, `Index::to_oci`, and CLI `copy`/`push` so the first error aborts the operation.
+- **#5/#19** Chunked-upload `Location` handling: `start_blob_upload` parses and resolves the upload URL; `upload_part` and `finish_blob_upload` PATCH/PUT against the URL returned by the previous response (preserving any pre-existing query string) instead of reformatting `/v2/{repo}/blobs/uploads/{upload}`.
+- **#6** Removed all `_progress` API duplication: `Layer::create`, `Layer::open`, `Image::filesystem`, `Image::to_tarball`, and `Index::to_oci` now take `Option<&dyn ProgressReporter>` (or `SharedProgress` where spawning is required).
+- **#7** Compression: `lz4` now returns `Error::Unsupported` instead of misusing the LZMA decoder. `Decompress::new` is fallible; `DockerImageRootfs(None)` passes through uncompressed.
+- **#8** Writer rewritten as an explicit state machine (`Initial → Starting → Idle ↔ Uploading → Finishing → Done`) with no `wake_by_ref`. Hash and offset advance only after the registry confirms each part. `Done` rejects further writes; `poll_shutdown` drains.
+- **#9** Auth precedence enforced: `.finch` → `.docker` → keyring; loop breaks on the first hit and never overwrites a resolved token with `None`.
+- **#10** Layer copy now advances by `read_size`, not `chunk_size` (was a real bug for `size < MIN_CHUNK_SIZE`); covered by `copy_handles_short_reads` test.
+- **#11** Spawned `JoinError`s now map to a typed `Error::Join` variant rather than being context-shifted into a generic error.
+- **#12** `Reader::poll_read` ticks progress by `after - before` per poll instead of only at EOF.
+- **#13** Reader validates streamed size and digest against expected values at EOF and returns `LayerSizeMismatch` / `DigestMismatch`.
+- **#14** `RegistryClient` upload methods now take `&self`.
+- **#15** `Ctx` exposes a single Arc-backed `SharedProgress` instead of leaking a `MultiProgress`; spawned tasks clone the `Arc` rather than relying on `unsafe` lifetime extension.
+
 ## [0.1.0](https://github.com/awslabs/ocilot/compare/v0.1.0-beta.2...v0.1.0) - 2026-04-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aegis"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07d39d15384924b35b70d7b8fa1f9a2934101dd3fa4722ede163cc4f9b7b960"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c6349ddff23194f8fdce2ea8849380f5a4868c1648965b70e801e104cba9b3"
+dependencies = [
+ "base64",
+ "jni 0.21.1",
+ "keyring-core",
+ "log",
+ "ndk-context",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -68,10 +140,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.6",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "arc-swap"
@@ -89,6 +188,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,10 +203,34 @@ dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -117,6 +246,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +316,30 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -324,11 +538,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.2",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
@@ -558,10 +772,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -570,6 +844,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -598,10 +894,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "byteorder"
@@ -635,6 +960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +977,22 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -657,6 +1006,46 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -751,6 +1140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +1156,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -796,11 +1194,29 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -813,12 +1229,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -865,6 +1335,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "serde",
+]
+
+[[package]]
+name = "db-keystore"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a1b2f1087c32a26a8c6c7d89eb80b50c33d8466e2431ea2a8345c969cded18"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "keyring-core",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "turso",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,8 +1385,27 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -896,13 +1419,24 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -945,6 +1479,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1538,44 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
 ]
 
 [[package]]
@@ -1005,6 +1623,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1651,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1068,6 +1707,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1757,46 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1148,6 +1840,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1873,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1188,10 +1902,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -1199,7 +1937,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1344,6 +2082,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,10 +2240,40 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "vt100",
  "web-time",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1495,6 +2287,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1545,6 +2355,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -1552,10 +2378,10 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1571,6 +2397,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1615,17 +2450,37 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "3.6.3"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "3f9933a54d9cdbab06776a617dfd0cbc320407e04402eb51bfbf7a5e1f583b5e"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
+ "android-native-keyring-store",
+ "apple-native-keyring-store",
+ "base64",
+ "clap",
+ "db-keystore",
+ "dbus-secret-service-keyring-store",
+ "keyring-core",
+ "linux-keyutils-keyring-store",
+ "rpassword",
+ "rprompt",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "chrono",
+ "dashmap",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
+ "regex",
+ "ron",
+ "serde",
+ "uuid",
 ]
 
 [[package]]
@@ -1633,6 +2488,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -1658,7 +2519,18 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -1680,6 +2552,67 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39fbed79f71dc21eb21d3d07c0e908a3c58ff9a1fdbf5cf44230fb3deb6d994b"
+dependencies = [
+ "keyring-core",
+ "linux-keyutils",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1709,6 +2642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,10 +2676,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1757,12 +2749,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1777,6 +2818,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1812,10 +2875,11 @@ dependencies = [
  "indicatif",
  "jiff",
  "keyring",
+ "keyring-core",
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "snafu",
  "tempfile",
  "tokio",
@@ -1839,16 +2903,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pack1"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1874,6 +3022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,10 +3046,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1947,12 +3138,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1966,10 +3189,10 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1985,13 +3208,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2033,13 +3256,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2049,7 +3299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2062,12 +3321,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2151,6 +3440,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
+dependencies = [
+ "bitflags",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rprompt"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69abf524bb9ccb7c071f7231441288d74b48d176cb309eb00e6f77d186c6e035"
+dependencies = [
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +3516,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,7 +3547,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2201,7 +3574,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -2222,14 +3595,14 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2284,22 +3657,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "security-framework"
-version = "2.11.1"
+name = "secret-service"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
 ]
 
 [[package]]
@@ -2375,14 +3760,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2396,9 +3809,35 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_pcg",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2431,6 +3870,21 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2476,6 +3930,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "softaes"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,10 +3948,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -2546,6 +4034,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,8 +4048,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2564,7 +4067,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2594,6 +4108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2705,6 +4220,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +4303,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2829,16 +4387,242 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "turso"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832bb70436d4b4d3ed45285c5c6abd62328d5e2486297b32cf2b0812abeba6d4"
+dependencies = [
+ "mimalloc",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8ef95330369724a1829b20dc1b728d644eaeb051891971b5d2b5617337a84b"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "antithesis_sdk",
+ "arc-swap",
+ "bigdecimal",
+ "bitflags",
+ "branches",
+ "bumpalo",
+ "bytemuck",
+ "cfg_aliases",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-skiplist",
+ "either",
+ "fallible-iterator",
+ "fastbloom",
+ "hex",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "pastey",
+ "polling",
+ "rand 0.9.4",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a47927d766b9ae7e3adf092d5e150dce80533615edc502641797878f190080"
+dependencies = [
+ "chrono",
+ "getrandom 0.4.2",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0cdc6ae079c61aa21a89b595a4d0e19d9d848a2658542252e82f930c57c3d87"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b94707e5605411cddbd5a1bd6cc2d6b72181b02223b36b37ba350ed6b71877"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "miette",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12a86ce113e5dcedeaad7809d9fa1dc00f837f40ccd8012ac1d2144c57672a34"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca6ee03a3dc5a48a7a63ddd2c8f41aa7bb5195eb96f6a29831447c8cb3d841a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c58fe60f17b694f91bd278e93aceca10fb340950f6a8f1aedef11c28b50c4b8"
+dependencies = [
+ "base64",
+ "bytes",
+ "genawaiter",
+ "http 1.4.2",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4512c7b28bb3bc09be1ba480ee60234ed9bbeb6686c9348323589ffcec504b93"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.4",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2857,6 +4641,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -2900,7 +4694,10 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -2909,6 +4706,18 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -2923,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
 ]
 
@@ -3112,6 +4921,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,10 +4942,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3157,9 +5026,27 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3180,6 +5067,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3217,6 +5119,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3229,6 +5137,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3238,6 +5152,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3265,6 +5185,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3274,6 +5200,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3289,6 +5221,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3301,6 +5239,12 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -3310,6 +5254,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -3412,13 +5365,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3448,6 +5410,78 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -3576,4 +5610,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,15 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,9 +90,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -146,15 +146,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -164,11 +164,12 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "time",
  "tokio",
  "tracing",
@@ -189,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -199,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -211,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -226,7 +227,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -236,10 +237,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.115.1"
+version = "1.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e30c797e7df731ba0c9d051b2f82a95526fd1fb3905185908d1b77d6e0a1386"
+checksum = "abb245a92534cda12d4e33929f95f9f73641c3e78115c5dcf6f8daf061bfa179"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -253,17 +255,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ecrpublic"
-version = "1.101.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f5754e124925336a6ea6407e78b21b402102c4fdf93e928502aa90f27151db"
+checksum = "52112d7d443181bb9402df79877f1c6c2ecba0d84de00103df6f6d338a4c282b"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -277,17 +280,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -302,16 +306,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -322,7 +326,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "percent-encoding",
  "sha2",
  "time",
@@ -352,7 +356,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -363,15 +367,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -387,10 +391,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -415,20 +421,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -440,16 +447,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -468,17 +475,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -504,13 +522,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -540,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -555,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "b2f04f6fef12d70d42a77b1433c9e0f065238479a6cefc4f5bab105e9873a3c3"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -565,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "7d0bd4c2f75335ad98052a37efb54f428b492f64340257143b3429c8a508fa7b"
 dependencies = [
  "darling",
  "ident_case",
@@ -580,9 +599,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -611,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -632,20 +657,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chrono"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
 
 [[package]]
 name = "clap"
@@ -698,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -803,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -854,6 +865,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
@@ -876,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -893,9 +925,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -936,13 +968,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1118,16 +1149,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1146,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1193,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1219,7 +1250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -1230,7 +1261,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1243,25 +1274,25 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1277,7 +1308,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1297,7 +1328,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -1310,30 +1341,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1458,7 +1465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1484,16 +1491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1501,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1566,13 +1604,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1582,7 +1619,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "dbus-secret-service",
  "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -1600,15 +1642,24 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "liblzma"
@@ -1628,18 +1679,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1665,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -1686,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -1708,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1728,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1767,11 +1806,11 @@ dependencies = [
  "bon",
  "bytes",
  "cfg-if",
- "chrono",
  "clap",
  "futures",
  "home",
  "indicatif",
+ "jiff",
  "keyring",
  "reqwest",
  "serde",
@@ -1829,7 +1868,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1859,16 +1898,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2029,15 +2071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,15 +2089,15 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2072,7 +2105,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -2161,14 +2194,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2196,7 +2229,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2255,6 +2288,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -2317,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2350,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2400,18 +2446,18 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snafu"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2421,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2598,9 +2644,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2675,20 +2721,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2784,9 +2830,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2850,9 +2896,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2936,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2949,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2959,9 +3005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2969,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2982,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -3038,9 +3084,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3072,41 +3118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3418,9 +3429,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3441,18 +3452,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3461,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3485,6 +3496,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,16 @@ base64 = "0.22"
 bon = "3"
 bytes = "1.11"
 cfg-if = "1.0"
-chrono = { version = "0.4", features = ["serde"] }
+jiff = { version = "0.2", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 indicatif = { version = "0.18", optional = true }
 home = "0.5"
-keyring = "3.6"
+keyring = { version = "3", features = [
+    "apple-native",
+    "windows-native",
+    "sync-secret-service",
+] }
 reqwest = { version = "0.13", features = [
     "json",
     "stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,8 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 indicatif = { version = "0.18", optional = true }
 home = "0.5"
-keyring = { version = "3", features = [
-    "apple-native",
-    "windows-native",
-    "sync-secret-service",
-] }
+keyring = "4"
+keyring-core = "1"
 reqwest = { version = "0.13", features = [
     "json",
     "stream",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,14 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::digest::Digest;
 use crate::models::Token;
 use crate::{Result, error};
 use async_trait::async_trait;
 use bytes::Bytes;
+use reqwest::header::LOCATION;
 use reqwest::{RequestBuilder, Response};
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use url::Url;
 
 /// A trait for a client implementing requests to an OCI registry.
@@ -24,7 +26,7 @@ pub(crate) trait RegistryClientImpl: Send + Sync + Debug {
     async fn get_blob(&self, uri: &Url, repository: &str, digest: &str) -> Result<Response>;
     /// DELETE {uri}/v2/{repository}/blobs/{digest}
     async fn del_blob(&self, uri: &Url, repository: &str, digest: &str) -> Result<Response>;
-    /// POST {url}/v2/{repository}/blobs/uploads/
+    /// POST {url}/v2/{repository}/blobs/uploads/?digest={digest} (monolithic upload)
     async fn post_blob(
         &self,
         uri: &Url,
@@ -32,22 +34,20 @@ pub(crate) trait RegistryClientImpl: Send + Sync + Debug {
         data: Bytes,
         digest: &str,
     ) -> Result<Response>;
-    /// POST {url}/v2/{repository}/blobs/uploads/ START chunked upload
+    /// POST {url}/v2/{repository}/blobs/uploads/ to start a chunked upload.
     async fn start_upload(&self, uri: &Url, repository: &str) -> Result<Response>;
-    /// PATCH {url}/v2/{upload_url}
+    /// PATCH against an upload URL returned by the registry.
     async fn upload_part(
         &self,
-        uri: &Url,
-        upload: &str,
+        upload_url: &Url,
         data: Bytes,
         start: usize,
         end: usize,
     ) -> Result<Response>;
-    /// PUT {url}/v2/{upload_url}
+    /// PUT against an upload URL with the final digest query parameter.
     async fn finish_blob_upload(
         &self,
-        uri: &Url,
-        upload: &str,
+        upload_url: &Url,
         data: Bytes,
         digest: &str,
         start: usize,
@@ -173,20 +173,19 @@ impl RegistryClientImpl for SimpleRegistryClient {
 
     async fn upload_part(
         &self,
-        uri: &Url,
-        upload: &str,
+        upload_url: &Url,
         data: Bytes,
         start: usize,
         end: usize,
     ) -> Result<Response> {
-        let request = self.client.patch(
-            uri.join(&format!("/v2/{}/blobs/uploads/{}", upload, upload))
-                .context(error::UrlSnafu)?,
-        );
+        // Content-Range uses inclusive endpoints per RFC 7233; callers pass the
+        // exclusive end (`start + len`) so subtract 1 for the wire format.
+        let last = end.saturating_sub(1);
+        let request = self.client.patch(upload_url.clone());
         self.auth(request)
             .header("Content-Type", "application/octet-stream")
             .header("Content-Length", data.len())
-            .header("Content-Range", format!("{}-{}", start, end))
+            .header("Content-Range", format!("{}-{}", start, last))
             .body(data)
             .send()
             .await
@@ -195,26 +194,33 @@ impl RegistryClientImpl for SimpleRegistryClient {
 
     async fn finish_blob_upload(
         &self,
-        uri: &Url,
-        upload: &str,
+        upload_url: &Url,
         data: Bytes,
         digest: &str,
         start: usize,
         end: usize,
     ) -> Result<Response> {
-        let mut uri = uri
-            .join(&format!("/v2/{}/blobs/uploads/{}", upload, upload))
-            .context(error::UrlSnafu)?;
-        uri.set_query(Some(format!("digest={digest}").as_str()));
+        let mut uri = upload_url.clone();
+        // Append digest while preserving any pre-existing query params placed
+        // there by the registry (some, like ECR, embed signature material).
+        let new_query = match uri.query() {
+            Some(existing) if !existing.is_empty() => format!("{existing}&digest={digest}"),
+            _ => format!("digest={digest}"),
+        };
+        uri.set_query(Some(&new_query));
         let request = self.client.put(uri);
-        self.auth(request)
-            .header("Content-Type", "application/octet-stream")
-            .header("Content-Length", data.len())
-            .header("Content-Range", format!("{}-{}", start, end))
-            .body(data)
-            .send()
-            .await
-            .context(error::RequestSnafu)
+        let request = if data.is_empty() {
+            self.auth(request).header("Content-Length", 0)
+        } else {
+            // Inclusive end byte per RFC 7233 / OCI distribution spec.
+            let last = end.saturating_sub(1);
+            self.auth(request)
+                .header("Content-Type", "application/octet-stream")
+                .header("Content-Length", data.len())
+                .header("Content-Range", format!("{}-{}", start, last))
+                .body(data)
+        };
+        request.send().await.context(error::RequestSnafu)
     }
 
     async fn head_manifest(
@@ -268,7 +274,8 @@ impl RegistryClientImpl for SimpleRegistryClient {
 /// Handle to OCI registry HTTP operations.
 ///
 /// Wraps the underlying client implementation to enable dependency injection
-/// and unit testing.
+/// and unit testing. The inner trait already requires `Send + Sync + Debug`,
+/// so `Arc<dyn ...>` provides safe sharing without any `unsafe impl`.
 #[derive(Clone, Debug)]
 pub struct RegistryClient {
     client: Arc<dyn RegistryClientImpl>,
@@ -313,51 +320,41 @@ impl RegistryClient {
     }
 
     pub async fn post_blob(
-        self,
+        &self,
         uri: Url,
         repository: String,
         data: Bytes,
         digest: String,
     ) -> Result<Response> {
         self.client
-            .as_ref()
             .post_blob(&uri, repository.as_str(), data, digest.as_str())
             .await
     }
 
-    pub async fn start_upload(self, uri: Url, repository: String) -> Result<Response> {
-        self.client
-            .as_ref()
-            .start_upload(&uri, repository.as_str())
-            .await
+    pub async fn start_upload(&self, uri: Url, repository: String) -> Result<Response> {
+        self.client.start_upload(&uri, repository.as_str()).await
     }
 
     pub async fn upload_part(
-        self,
-        uri: Url,
-        upload: String,
+        &self,
+        upload_url: Url,
         data: Bytes,
         start: usize,
         end: usize,
     ) -> Result<Response> {
-        self.client
-            .as_ref()
-            .upload_part(&uri, upload.as_str(), data, start, end)
-            .await
+        self.client.upload_part(&upload_url, data, start, end).await
     }
 
     pub async fn finish_blob_upload(
-        self,
-        uri: Url,
-        upload: String,
+        &self,
+        upload_url: Url,
         data: Bytes,
         digest: String,
         start: usize,
         end: usize,
     ) -> Result<Response> {
         self.client
-            .as_ref()
-            .finish_blob_upload(&uri, upload.as_str(), data, digest.as_str(), start, end)
+            .finish_blob_upload(&upload_url, data, digest.as_str(), start, end)
             .await
     }
 
@@ -407,5 +404,21 @@ impl RegistryClient {
     }
 }
 
-unsafe impl Send for RegistryClient {}
-unsafe impl Sync for RegistryClient {}
+/// Extract the `Location` header from a response and resolve it against the
+/// request base URL. Registries are allowed to return either an absolute URL
+/// (ECR commonly does this with a different host) or a relative path.
+pub(crate) fn extract_location(response: &Response, base: &Url) -> crate::Result<Url> {
+    let header = response
+        .headers()
+        .get(LOCATION)
+        .context(error::StartBlobNoLocationSnafu)?
+        .to_str()
+        .context(error::ImproperHeaderSnafu)?;
+    base.join(header).context(error::UrlSnafu)
+}
+
+/// Convenience: validate a digest string and return the canonical form.
+#[allow(dead_code)]
+pub(crate) fn validate_digest(digest: &str) -> crate::Result<Digest> {
+    Digest::parse(digest)
+}

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,9 +1,9 @@
+use super::context::Ctx;
 use clap::Parser;
-use snafu::{OptionExt, ResultExt};
 use ocilot::error;
 use ocilot::index::Index;
 use ocilot::uri::Uri;
-use super::context::Ctx;
+use snafu::{OptionExt, ResultExt};
 
 #[derive(Parser, Debug)]
 #[command(version, about = "Get the config of an image", long_about = None)]
@@ -20,8 +20,9 @@ impl Config {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
         let index = Index::fetch(&uri).await?;
+        let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
         let image = index
-            .fetch_image(&uri, self.platform.clone().map(|x| x.into()))
+            .fetch_image(&uri, platform)
             .await?
             .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
         let config = image.fetch_config(&uri).await?;

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -1,10 +1,15 @@
 use cfg_if::cfg_if;
-use indicatif::MultiProgress;
+use ocilot::progress::SharedProgress;
 use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Application context passed through command execution.
+///
+/// Holds a single `SharedProgress` (Arc-backed) that all commands clone
+/// when calling library APIs. With the `progress` feature this wraps the
+/// `indicatif` reporter; without it, [`SharedProgress::none`] is used so
+/// progress calls become no-ops.
 pub struct Ctx {
-    multi: MultiProgress,
+    progress: SharedProgress,
 }
 
 impl Ctx {
@@ -19,20 +24,26 @@ impl Ctx {
                     )
                     .with(indicatif_layer.with_filter(EnvFilter::from_default_env()))
                     .try_init()
-                    .unwrap();
+                    .ok();
+                let multi = indicatif::MultiProgress::new();
+                let reporter = std::sync::Arc::new(
+                    ocilot::progress::IndicatifReporter::new(multi),
+                );
+                let progress = SharedProgress::new(reporter);
             } else {
                 tracing_subscriber::registry()
                     .with(tracing_subscriber::fmt::layer().with_filter(EnvFilter::from_default_env()))
                     .try_init()
-                    .unwrap();;
-
+                    .ok();
+                let progress = SharedProgress::none();
             }
         }
-        let multi = MultiProgress::new();
-        Ok(Self { multi })
+        Ok(Self { progress })
     }
 
-    pub fn get(&mut self) -> &mut MultiProgress {
-        &mut self.multi
+    /// Get a clone of the shared progress reporter to hand off to library
+    /// calls. Cheap (single Arc clone).
+    pub fn progress(&self) -> SharedProgress {
+        self.progress.clone()
     }
 }

--- a/src/cmd/copy.rs
+++ b/src/cmd/copy.rs
@@ -2,14 +2,15 @@ use std::str::FromStr;
 
 use super::context::Ctx;
 use clap::Parser;
-use futures::future::join_all;
+use futures::future::try_join_all;
 use ocilot::{
-    Result,
+    Result, error,
     image::Image,
     index::Index,
     layer::Layer,
     uri::{Reference, Uri},
 };
+use snafu::ResultExt;
 use tokio::task::JoinHandle;
 
 #[derive(Parser, Debug)]
@@ -30,7 +31,7 @@ impl Copy {
         let mut target = Uri::new(self.target.as_str()).await?;
         target.set_secure(!self.target_insecure);
         let index = Index::fetch(&source).await?;
-        let multi = ctx.get();
+        let progress = ctx.progress();
         for manifest in index.manifests().iter() {
             let manifest_uri = Uri::builder()
                 .registry(source.registry().clone())
@@ -38,24 +39,22 @@ impl Copy {
                 .reference(Reference::from_str(manifest.digest())?)
                 .build();
             let image = Image::fetch(&manifest_uri, manifest.platform().clone()).await?;
-            // Copy the config over, note we do not use progress bars for the read
+            // Copy the config over
             let config_uri = Uri::builder()
                 .registry(target.registry().clone())
                 .repository(target.repository())
                 .reference(Reference::from_str(image.config().digest())?)
                 .build();
-            let digest = &image.config().digest().strip_prefix("sha256:").unwrap()[0..9];
-            let mut writer = Layer::create_progress(
+            let mut writer = Layer::create(
                 &config_uri,
                 image.config().media_type(),
-                format!("blob {digest}").as_str(),
-                image.config().size() as u64,
-                multi,
+                image.config().size(),
                 Some(image.config().digest().to_string()),
+                progress.as_ref(),
             )
             .await?;
             if let Some(writer) = writer.as_mut() {
-                let mut reader = image.config().open(&source).await?;
+                let mut reader = image.config().open(&source, progress.as_ref()).await?;
                 Layer::copy(&mut reader, writer, image.config().size()).await?;
                 writer.layer().await?;
             }
@@ -65,27 +64,31 @@ impl Copy {
                 let source_uri = source.clone();
                 let target_uri = target.clone();
                 let layer = layer.clone();
-                let mut multi = multi.clone();
+                let progress = progress.clone();
                 tasks.push(tokio::spawn(async move {
-                    let digest = &layer.digest().strip_prefix("sha256:").unwrap()[0..9];
-                    let mut writer = Layer::create_progress(
+                    let mut writer = Layer::create(
                         &target_uri,
                         layer.media_type(),
-                        format!("blob {digest}").as_str(),
-                        layer.size() as u64,
-                        &mut multi,
+                        layer.size(),
                         Some(layer.digest().to_string()),
+                        progress.as_ref(),
                     )
                     .await?;
                     if let Some(writer) = writer.as_mut() {
-                        let mut reader = layer.open(&source_uri).await?;
+                        let mut reader = layer.open(&source_uri, progress.as_ref()).await?;
                         Layer::copy(&mut reader, writer, layer.size()).await?;
                         writer.layer().await?;
                     }
                     Ok(())
                 }));
             }
-            join_all(tasks).await;
+            // try_join_all aborts on first error and reports JoinErrors
+            // through the typed Error::Join variant (#4 + #11).
+            try_join_all(tasks)
+                .await
+                .context(error::JoinSnafu)?
+                .into_iter()
+                .collect::<Result<Vec<_>>>()?;
             let target_manifest_uri = Uri::builder()
                 .registry(target.registry().clone())
                 .repository(target.repository())

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -24,16 +24,17 @@ impl Export {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
         let index = Index::fetch(&uri).await?;
+        let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
         let image = index
-            .fetch_image(&uri, self.platform.clone().map(|x| x.into()))
+            .fetch_image(&uri, platform)
             .await?
             .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
 
         let file = tokio::fs::File::create(&self.output)
             .await
             .context(error::FileSnafu)?;
-        let multi = ctx.get();
-        image.filesystem_progress(&uri, file, multi).await?;
+        let progress = ctx.progress();
+        image.filesystem(&uri, file, progress.as_ref()).await?;
         Ok(())
     }
 }

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -82,7 +82,7 @@ impl AddIndex {
         };
 
         // Now load the manifest we want to add
-        let platform: Option<Platform> = self.platform.clone().map(|x| x.into());
+        let platform: Option<Platform> = self.platform.clone().map(|x| x.parse()).transpose()?;
         // If a platform is set and reference is a tag we can use an index to find the right
         // image
         let image = if let Some(platform) = platform.as_ref() {

--- a/src/cmd/manifest.rs
+++ b/src/cmd/manifest.rs
@@ -22,7 +22,7 @@ impl Manifest {
     pub async fn run(&self, _ctx: &Ctx) -> Result<(), error::Error> {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let platform: Option<Platform> = self.platform.clone().map(|x| x.into());
+        let platform: Option<Platform> = self.platform.clone().map(|x| x.parse()).transpose()?;
         let index = Index::fetch(&uri).await?;
         let image = index.fetch_image(&uri, platform).await?;
         println!(

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -34,21 +34,21 @@ impl Pull {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
         let index = Index::fetch(&uri).await?;
-        let platform = self.platform.clone().map(|x| x.into());
+        let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
 
         let output = tokio::fs::File::create(&self.output)
             .await
             .context(error::FileSnafu)?;
-        let multi = ctx.get();
+        let progress = ctx.progress();
         match self.format {
             Format::Tarball => {
                 let image = index
                     .fetch_image(&uri, platform.clone())
                     .await?
                     .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
-                image.to_tarball_progress(&uri, output, multi).await?
+                image.to_tarball(&uri, output, progress).await?
             }
-            Format::Oci => index.to_oci_progress(&uri, platform, output, multi).await?,
+            Format::Oci => index.to_oci(&uri, platform, output, progress).await?,
         }
 
         Ok(())

--- a/src/cmd/push.rs
+++ b/src/cmd/push.rs
@@ -4,7 +4,8 @@ use std::str::FromStr;
 use async_recursion::async_recursion;
 use clap::Parser;
 use futures::StreamExt;
-use futures::future::join_all;
+use futures::future::try_join_all;
+use ocilot::digest::Digest;
 use ocilot::error;
 use ocilot::image::Image;
 use ocilot::index::Index;
@@ -34,7 +35,7 @@ impl Push {
     pub async fn run(&self, ctx: &mut Ctx) -> Result<(), error::Error> {
         let mut uri = Uri::new(self.uri.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let multi = ctx.get();
+        let progress = ctx.progress();
         let mut archive = File::open(&self.archive).await.context(error::FileSnafu)?;
         // We need to find the index first
         let mut index_entry = afind(&mut archive, |x| x.ends_with("index.json"))
@@ -49,8 +50,8 @@ impl Push {
             serde_json::from_slice(buffer.as_slice()).context(error::ImageInvalidIndexSnafu)?;
         index = find_index(&mut archive, &index).await?;
         for manifest in index.manifests().iter() {
-            let digest = manifest.digest().split_once(':').unwrap().1;
-            let mut blob_entry = afind(&mut archive, |x| x.ends_with(digest))
+            let manifest_digest = Digest::parse(manifest.digest())?;
+            let mut blob_entry = afind(&mut archive, |x| x.ends_with(manifest_digest.hex()))
                 .await?
                 .context(error::BlobMissingSnafu {
                     digest: manifest.digest(),
@@ -63,8 +64,8 @@ impl Push {
             let image: Image = serde_json::from_slice(buffer.as_slice())
                 .context(error::ImageInvalidManifestSnafu)?;
             // First lets copy the config blob
-            let cdigest = image.config().digest().split_once(':').unwrap().1;
-            let mut config_entry = afind(&mut archive, |x| x.ends_with(cdigest))
+            let config_digest = Digest::parse(image.config().digest())?;
+            let mut config_entry = afind(&mut archive, |x| x.ends_with(config_digest.hex()))
                 .await?
                 .context(error::BlobMissingSnafu {
                     digest: image.config().digest(),
@@ -74,13 +75,12 @@ impl Push {
                 .entry_size()
                 .context(error::ArchiveSnafu)?;
 
-            let mut writer = Layer::create_progress(
+            let mut writer = Layer::create(
                 &uri,
                 image.config().media_type(),
-                format!("blob {}", &cdigest[0..9]).as_str(),
-                config_size,
-                multi,
+                config_size as usize,
                 Some(image.config().digest().to_string()),
+                progress.as_ref(),
             )
             .await?;
             if let Some(writer) = writer.as_mut() {
@@ -93,10 +93,10 @@ impl Push {
                 let mut larchive = File::open(&self.archive).await.context(error::FileSnafu)?;
                 let layer = layer.clone();
                 let uri = uri.clone();
-                let mut multi = multi.clone();
+                let progress = progress.clone();
                 tasks.push(tokio::spawn(async move {
-                    let ldigest = layer.digest().split_once(":").unwrap().1;
-                    let mut layer_entry = afind(&mut larchive, |x| x.ends_with(ldigest))
+                    let layer_digest = Digest::parse(layer.digest())?;
+                    let mut layer_entry = afind(&mut larchive, |x| x.ends_with(layer_digest.hex()))
                         .await?
                         .context(error::BlobMissingSnafu {
                             digest: layer.digest(),
@@ -105,13 +105,12 @@ impl Push {
                         .header()
                         .entry_size()
                         .context(error::ArchiveSnafu)?;
-                    let mut writer = Layer::create_progress(
+                    let mut writer = Layer::create(
                         &uri,
                         layer.media_type(),
-                        format!("blob {}", &ldigest[0..9]).as_str(),
-                        layer_size,
-                        &mut multi,
+                        layer_size as usize,
                         Some(layer.digest().to_string()),
+                        progress.as_ref(),
                     )
                     .await?;
                     if let Some(writer) = writer.as_mut() {
@@ -121,10 +120,11 @@ impl Push {
                     Ok(())
                 }));
             }
-            for result in join_all(tasks).await {
-                let result = result.expect("failed to join");
-                result?;
-            }
+            try_join_all(tasks)
+                .await
+                .context(error::JoinSnafu)?
+                .into_iter()
+                .collect::<Result<Vec<_>, error::Error>>()?;
             let manifest_uri = Uri::builder()
                 .registry(uri.registry().clone())
                 .repository(uri.repository())
@@ -166,13 +166,12 @@ where
 #[async_recursion]
 async fn find_index<'a>(archive: &'a mut File, index: &Index) -> Result<Index, error::Error> {
     for manifest in index.manifests().iter() {
-        let digest = manifest.digest().split_once(':').unwrap().1;
-        let mut blob_entry =
-            afind(archive, |x| x.ends_with(digest))
-                .await?
-                .context(error::BlobMissingSnafu {
-                    digest: manifest.digest(),
-                })?;
+        let manifest_digest = Digest::parse(manifest.digest())?;
+        let mut blob_entry = afind(archive, |x| x.ends_with(manifest_digest.hex()))
+            .await?
+            .context(error::BlobMissingSnafu {
+                digest: manifest.digest(),
+            })?;
         let mut buffer = Vec::new();
         blob_entry
             .read_to_end(&mut buffer)

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,47 +1,62 @@
 use std::pin::Pin;
 
-use async_compression::tokio::bufread::{
-    BzDecoder, GzipDecoder, LzmaDecoder, XzDecoder, ZstdDecoder,
-};
+use async_compression::tokio::bufread::{BzDecoder, GzipDecoder, XzDecoder, ZstdDecoder};
 use tokio::io::AsyncRead;
 use tokio::io::BufReader;
 
 use crate::{
+    error,
     layer::Reader,
     models::{Compression, MediaType},
 };
 
+/// A decompressing wrapper around a [`Reader`].
+///
+/// The inner stream is bound by `Send + Sync` so the type can be used
+/// across thread boundaries (e.g. with `tokio::spawn`) without any unsafe
+/// impls.
 pub struct Decompress {
-    inner: Pin<Box<dyn AsyncRead>>,
+    inner: Pin<Box<dyn AsyncRead + Send + Sync>>,
 }
 
-unsafe impl Send for Decompress {}
-unsafe impl Sync for Decompress {}
-
 impl Decompress {
-    pub fn new(media: &MediaType, reader: Reader) -> Self {
-        Self {
-            inner: match media {
-                MediaType::DockerImageRootfs(compression) => match compression {
-                    Compression::Gzip | Compression::None => {
-                        Box::pin(GzipDecoder::new(BufReader::new(reader)))
+    /// Construct a new decompressor for the given media type around a
+    /// [`Reader`]. Returns an `Unsupported` error for layer formats this
+    /// crate cannot transparently decode (currently lz4).
+    pub fn new(media: &MediaType, reader: Reader) -> crate::Result<Self> {
+        let inner: Pin<Box<dyn AsyncRead + Send + Sync>> = match media {
+            // Docker rootfs layers historically default to gzip when the
+            // media type does not encode a compression suffix; spec calls
+            // this an "uncompressed" diff which is a misnomer in practice.
+            MediaType::DockerImageRootfs(compression) => match compression {
+                Compression::Gzip => Box::pin(GzipDecoder::new(BufReader::new(reader))),
+                Compression::Bzip2 => Box::pin(BzDecoder::new(BufReader::new(reader))),
+                Compression::Xz => Box::pin(XzDecoder::new(BufReader::new(reader))),
+                Compression::Zstd => Box::pin(ZstdDecoder::new(BufReader::new(reader))),
+                Compression::None => Box::pin(BufReader::new(reader)),
+                Compression::Lz4 => {
+                    return error::UnsupportedSnafu {
+                        reason: "lz4 layer decompression is not supported".to_string(),
                     }
-                    Compression::Bzip2 => Box::pin(BzDecoder::new(BufReader::new(reader))),
-                    Compression::Lz4 => Box::pin(LzmaDecoder::new(BufReader::new(reader))),
-                    Compression::Xz => Box::pin(XzDecoder::new(BufReader::new(reader))),
-                    Compression::Zstd => Box::pin(ZstdDecoder::new(BufReader::new(reader))),
-                },
-                MediaType::Layer(compression) => match compression {
-                    Compression::Gzip => Box::pin(GzipDecoder::new(BufReader::new(reader))),
-                    Compression::Bzip2 => Box::pin(BzDecoder::new(BufReader::new(reader))),
-                    Compression::Lz4 => Box::pin(LzmaDecoder::new(BufReader::new(reader))),
-                    Compression::Xz => Box::pin(XzDecoder::new(BufReader::new(reader))),
-                    Compression::Zstd => Box::pin(ZstdDecoder::new(BufReader::new(reader))),
-                    Compression::None => Box::pin(BufReader::new(reader)),
-                },
-                _ => Box::pin(BufReader::new(reader)),
+                    .fail();
+                }
             },
-        }
+            MediaType::Layer(compression) => match compression {
+                Compression::Gzip => Box::pin(GzipDecoder::new(BufReader::new(reader))),
+                Compression::Bzip2 => Box::pin(BzDecoder::new(BufReader::new(reader))),
+                Compression::Xz => Box::pin(XzDecoder::new(BufReader::new(reader))),
+                Compression::Zstd => Box::pin(ZstdDecoder::new(BufReader::new(reader))),
+                Compression::None => Box::pin(BufReader::new(reader)),
+                Compression::Lz4 => {
+                    return error::UnsupportedSnafu {
+                        reason: "lz4 layer decompression is not supported".to_string(),
+                    }
+                    .fail();
+                }
+            },
+            _ => Box::pin(BufReader::new(reader)),
+        };
+        Ok(Self { inner })
     }
 }
 

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,211 @@
+//! Strongly-typed OCI content digest values.
+//!
+//! Spec: <https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests>
+//!
+//! A digest takes the form `algorithm:hex` where `algorithm` is a token
+//! (e.g. `sha256`, `sha512`) and the hex portion is the lowercase hex
+//! encoding of the digest produced by that algorithm.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::error;
+
+/// A validated `algorithm:hex` digest reference.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Digest {
+    raw: String,
+    algo_end: usize,
+}
+
+impl Digest {
+    /// Parse the input string into a digest, validating the form
+    /// `algorithm:hex_digits` where `hex_digits` length matches the algorithm
+    /// (when known).
+    pub fn parse(input: &str) -> crate::Result<Self> {
+        let (algo, hex) = input
+            .split_once(':')
+            .ok_or_else(|| error::Error::InvalidDigest {
+                reason: format!("expected '<algorithm>:<hex>', got '{input}'"),
+            })?;
+        if algo.is_empty() {
+            return Err(error::Error::InvalidDigest {
+                reason: "algorithm component is empty".to_string(),
+            });
+        }
+        if hex.is_empty() {
+            return Err(error::Error::InvalidDigest {
+                reason: "hex component is empty".to_string(),
+            });
+        }
+        if !algo
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '.' || c == '-' || c == '_')
+        {
+            return Err(error::Error::InvalidDigest {
+                reason: format!("invalid characters in algorithm '{algo}'"),
+            });
+        }
+        if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(error::Error::InvalidDigest {
+                reason: format!("hex component '{hex}' contains non-hex characters"),
+            });
+        }
+        let expected_len = match algo {
+            "sha256" => Some(64),
+            "sha512" => Some(128),
+            _ => None,
+        };
+        if let Some(expected) = expected_len
+            && hex.len() != expected
+        {
+            return Err(error::Error::InvalidDigest {
+                reason: format!(
+                    "expected {} hex characters for {}, got {}",
+                    expected,
+                    algo,
+                    hex.len()
+                ),
+            });
+        }
+        Ok(Self {
+            raw: input.to_string(),
+            algo_end: algo.len(),
+        })
+    }
+
+    /// The algorithm component (e.g. `sha256`).
+    pub fn algorithm(&self) -> &str {
+        &self.raw[..self.algo_end]
+    }
+
+    /// The hex-encoded digest value (lowercase, validated).
+    pub fn hex(&self) -> &str {
+        // +1 for the colon separator.
+        &self.raw[self.algo_end + 1..]
+    }
+
+    /// The full canonical `algorithm:hex` representation.
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    /// First N hex characters of the digest, used as a short label.
+    pub fn short(&self, n: usize) -> &str {
+        let hex = self.hex();
+        &hex[..n.min(hex.len())]
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+impl FromStr for Digest {
+    type Err = crate::error::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl Serialize for Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.raw)
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_sha256() {
+        let s = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let d = Digest::parse(s).expect("should parse");
+        assert_eq!(d.algorithm(), "sha256");
+        assert_eq!(d.hex().len(), 64);
+        assert_eq!(d.as_str(), s);
+        assert_eq!(d.short(9).len(), 9);
+    }
+
+    #[test]
+    fn parse_valid_sha512() {
+        let hex = "a".repeat(128);
+        let s = format!("sha512:{hex}");
+        let d = Digest::parse(&s).expect("sha512 should parse");
+        assert_eq!(d.algorithm(), "sha512");
+        assert_eq!(d.hex().len(), 128);
+    }
+
+    #[test]
+    fn parse_unknown_algo_skips_length_check() {
+        // Unknown algorithms accept any hex length so we stay forward-compat
+        // with future spec algorithms.
+        let d = Digest::parse("blake3:dead").expect("should parse");
+        assert_eq!(d.algorithm(), "blake3");
+        assert_eq!(d.hex(), "dead");
+    }
+
+    #[test]
+    fn rejects_missing_colon() {
+        assert!(Digest::parse("sha256-abcdef").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_algorithm() {
+        assert!(Digest::parse(":abcd").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_hex() {
+        assert!(Digest::parse("sha256:").is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_sha256_length() {
+        assert!(Digest::parse("sha256:abc").is_err());
+    }
+
+    #[test]
+    fn rejects_non_hex() {
+        let s = "sha256:".to_string() + &"z".repeat(64);
+        assert!(Digest::parse(&s).is_err());
+    }
+
+    #[test]
+    fn random_strings_never_panic() {
+        // Deterministic pseudo-random strings; we only care that parse
+        // returns Result without panicking.
+        let mut seed: u64 = 0x1234_5678_9abc_def0;
+        for _ in 0..1000 {
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let len = (seed % 80) as usize;
+            let s: String = (0..len)
+                .map(|i| {
+                    let b = ((seed >> (i % 56)) & 0xff) as u8;
+                    char::from(b.clamp(0x20, 0x7e))
+                })
+                .collect();
+            let _ = Digest::parse(&s);
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,32 @@ use crate::uri::Uri;
 pub enum Error {
     #[snafu(display("failed to interact with tar archive: {source}"))]
     Archive { source: std::io::Error },
-    #[snafu(display("failed to authorize with oci registry: {reason}"))]
-    Authorization { reason: String },
+    #[cfg(feature = "aws")]
+    #[snafu(display("failed to authorize with public ecr: {source}"))]
+    EcrPublicAuth {
+        source: aws_sdk_ecrpublic::error::SdkError<
+            aws_sdk_ecrpublic::operation::get_authorization_token::GetAuthorizationTokenError,
+        >,
+    },
+    #[cfg(feature = "aws")]
+    #[snafu(display("failed to authorize with private ecr: {source}"))]
+    EcrPrivateAuth {
+        source: aws_sdk_ecr::error::SdkError<
+            aws_sdk_ecr::operation::get_authorization_token::GetAuthorizationTokenError,
+        >,
+    },
+    #[snafu(display("{context}: invalid base64 in credential: {source}"))]
+    AuthBase64Decode {
+        context: &'static str,
+        source: base64::DecodeError,
+    },
+    #[snafu(display("{context}: credential payload is not valid utf-8: {source}"))]
+    AuthUtf8 {
+        context: &'static str,
+        source: std::str::Utf8Error,
+    },
+    #[snafu(display("{context}: credential is missing the ':' separator"))]
+    AuthMissingSeparator { context: &'static str },
     #[snafu(display("blob with digest {digest} is missing from oci archive"))]
     BlobMissing { digest: String },
     #[snafu(display("failed to deserialize image configuration received from registry: {source}"))]
@@ -71,6 +95,26 @@ pub enum Error {
     ImageNotValid,
     #[snafu(display("invalid algorithm in digest: {algorithm}"))]
     InvalidAlgorithm { algorithm: String },
+    #[snafu(display("invalid digest: {reason}"))]
+    InvalidDigest { reason: String },
+    #[snafu(display(
+        "invalid platform specifier '{value}': expected '<os>/<architecture>' (e.g. 'linux/amd64')"
+    ))]
+    InvalidPlatformFormat { value: String },
+    #[snafu(display(
+        "invalid platform specifier '{value}': os and architecture components must both be non-empty"
+    ))]
+    InvalidPlatformEmpty { value: String },
+    #[snafu(display("layer size mismatch: expected {expected} bytes, got {actual} bytes"))]
+    LayerSizeMismatch { expected: usize, actual: usize },
+    #[snafu(display("layer digest mismatch: expected {expected}, computed {actual}"))]
+    DigestMismatch { expected: String, actual: String },
+    #[snafu(display("unsupported operation: {reason}"))]
+    Unsupported { reason: String },
+    #[snafu(display("background task panicked or was cancelled: {source}"))]
+    Join { source: JoinError },
+    #[snafu(display("internal invariant violated: {context}"))]
+    Internal { context: &'static str },
     #[snafu(display("failed to unpack archive from layer: {source}"))]
     LayerArchive { source: std::io::Error },
     #[snafu(display("failed to copy from layer: {source}"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,15 +16,31 @@ pub enum Error {
     #[cfg(feature = "aws")]
     #[snafu(display("failed to authorize with public ecr: {source}"))]
     EcrPublicAuth {
-        source: aws_sdk_ecrpublic::error::SdkError<
-            aws_sdk_ecrpublic::operation::get_authorization_token::GetAuthorizationTokenError,
+        #[snafu(source(from(
+            aws_sdk_ecrpublic::error::SdkError<
+                aws_sdk_ecrpublic::operation::get_authorization_token::GetAuthorizationTokenError,
+            >,
+            Box::new
+        )))]
+        source: Box<
+            aws_sdk_ecrpublic::error::SdkError<
+                aws_sdk_ecrpublic::operation::get_authorization_token::GetAuthorizationTokenError,
+            >,
         >,
     },
     #[cfg(feature = "aws")]
     #[snafu(display("failed to authorize with private ecr: {source}"))]
     EcrPrivateAuth {
-        source: aws_sdk_ecr::error::SdkError<
-            aws_sdk_ecr::operation::get_authorization_token::GetAuthorizationTokenError,
+        #[snafu(source(from(
+            aws_sdk_ecr::error::SdkError<
+                aws_sdk_ecr::operation::get_authorization_token::GetAuthorizationTokenError,
+            >,
+            Box::new
+        )))]
+        source: Box<
+            aws_sdk_ecr::error::SdkError<
+                aws_sdk_ecr::operation::get_authorization_token::GetAuthorizationTokenError,
+            >,
         >,
     },
     #[snafu(display("{context}: invalid base64 in credential: {source}"))]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,16 +1,16 @@
 #[cfg(feature = "compression")]
 use crate::compression::Decompress;
+use crate::digest::Digest;
 use crate::error;
 use crate::layer::Layer;
 use crate::models::{Config, ImageConfig, MediaType, Platform, TarballManifest};
+use crate::progress::{ProgressReporter, SharedProgress};
 use crate::uri::{Reference, Uri};
 use bon::Builder;
 use futures::StreamExt;
-use futures::future::join_all;
-#[cfg(feature = "progress")]
-use indicatif::MultiProgress;
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
-use snafu::{ResultExt, ensure};
+use snafu::{OptionExt, ResultExt, ensure};
 use std::collections::HashSet;
 use tempfile::tempdir;
 use tokio::fs::File;
@@ -108,7 +108,7 @@ impl Image {
 
     /// Fetch and deserialize the image configuration from the registry
     pub async fn fetch_config(&self, uri: &Uri) -> crate::Result<ImageConfig> {
-        let mut layer = self.config.open(uri).await?;
+        let mut layer = self.config.open(uri, None).await?;
         let mut config = String::new();
         layer
             .read_to_string(&mut config)
@@ -117,11 +117,18 @@ impl Image {
         serde_json::from_str(config.as_str()).context(error::ConfigDeserializeSnafu)
     }
 
-    /// Extract the content of this image to filesystem. This method assumes that the layers are a series
-    /// of tar archives that can be extracted. It requires the compression feature in order to automatically
-    /// decompress the layers
+    /// Extract the content of this image to filesystem. This method assumes
+    /// that the layers are a series of tar archives that can be extracted.
+    /// It requires the compression feature in order to automatically
+    /// decompress the layers. Pass `Some(reporter)` for progress, `None`
+    /// for silent operation.
     #[cfg(feature = "compression")]
-    pub async fn filesystem<W>(&self, uri: &Uri, output: W) -> crate::Result<()>
+    pub async fn filesystem<W>(
+        &self,
+        uri: &Uri,
+        output: W,
+        progress: Option<&dyn ProgressReporter>,
+    ) -> crate::Result<()>
     where
         W: AsyncWrite + Unpin + Send + 'static,
     {
@@ -129,9 +136,9 @@ impl Image {
         let mut filemap: HashSet<String> = HashSet::new();
 
         for layer in self.layers.iter().rev() {
-            let reader = Decompress::new(layer.media_type(), layer.open(uri).await?);
+            let reader = Decompress::new(layer.media_type(), layer.open(uri, progress).await?)?;
             let mut layer = Archive::new(reader);
-            // Make sure to use the raw entry stream to avoid truncation of long links and long paths
+            // Use the raw entry stream to avoid truncation of long links and long paths.
             let mut entries = layer.entries_raw().context(error::LayerArchiveSnafu)?;
             while let Some(entry) = entries.next().await {
                 let mut entry = entry.context(error::LayerArchiveSnafu)?;
@@ -143,7 +150,6 @@ impl Image {
                 {
                     continue;
                 }
-
                 filemap.insert(path.to_string());
                 archive
                     .append(&header, &mut entry)
@@ -152,121 +158,22 @@ impl Image {
             }
         }
         archive.finish().await.context(error::ArchiveSnafu)?;
-
         Ok(())
     }
 
-    /// Extract the content of this image to filesystem. This method assumes that the layers are a series
-    /// of tar archives that can be extracted. It requires the compression feature in order to automatically
-    /// decompress the layers. It also reports to indicatif progress bars.
-    #[cfg(all(feature = "progress", feature = "compression"))]
-    pub async fn filesystem_progress<W>(
-        &self,
-        uri: &Uri,
-        output: W,
-        multi: &mut MultiProgress,
-    ) -> crate::Result<()>
-    where
-        W: AsyncWrite + Unpin + Send + 'static,
-    {
-        let mut archive = ArchiveBuilder::new(output);
-        let mut filemap: HashSet<String> = HashSet::new();
-
-        for layer in self.layers.iter().rev() {
-            let reader =
-                Decompress::new(layer.media_type(), layer.open_progress(uri, multi).await?);
-            let mut layer = Archive::new(reader);
-            // Make sure to use the raw entry stream to avoid truncation of long links and long paths
-            let mut entries = layer.entries_raw().context(error::LayerArchiveSnafu)?;
-            while let Some(entry) = entries.next().await {
-                let mut entry = entry.context(error::LayerArchiveSnafu)?;
-                let header = entry.header().clone();
-                let path = header.path().context(error::LayerArchiveSnafu)?;
-                let path = path.to_string_lossy();
-                if path.contains(WHITEOUT)
-                    || (header.entry_type().is_file() && filemap.contains(path.as_ref()))
-                {
-                    continue;
-                }
-
-                filemap.insert(path.to_string());
-                archive
-                    .append(&header, &mut entry)
-                    .await
-                    .context(error::LayerCopySnafu)?;
-            }
-        }
-        archive.finish().await.context(error::ArchiveSnafu)?;
-
-        Ok(())
-    }
-
-    /// Write this image out as a docker loadable tarball. This is NOT an oci archive and is primarily to be used with
-    /// docker/finch/podman/nerdctl load
+    /// Write this image out as a docker loadable tarball. This is NOT an
+    /// oci archive and is primarily to be used with
+    /// docker/finch/podman/nerdctl load. Pass a populated [`SharedProgress`]
+    /// for progress reporting or [`SharedProgress::none`] for silent
+    /// operation. `SharedProgress` is `Arc`-backed and `Clone` so it can
+    /// be moved into spawned tasks safely without `unsafe` lifetime
+    /// extension.
     #[cfg(feature = "compression")]
-    pub async fn to_tarball<W>(&self, uri: &Uri, output: W) -> crate::Result<()>
-    where
-        W: AsyncWrite + Unpin + Send + 'static,
-    {
-        let mut manifest = TarballManifest::builder()
-            .config(self.config.digest())
-            .repo_tags(vec![uri.to_string()])
-            .layers(vec![])
-            .build();
-        let tmp_dir = tempdir().context(error::TempSnafu)?;
-        let mut config_reader = self.config.open(uri).await?;
-        let mut config_file = File::create(tmp_dir.path().join(self.config.digest()))
-            .await
-            .context(error::FileSnafu)?;
-        Layer::copy(&mut config_reader, &mut config_file, self.config.size()).await?;
-
-        let mut tasks: Vec<JoinHandle<crate::Result<String>>> = Vec::new();
-        let tmp_path = tmp_dir.path().to_path_buf();
-        for layer in self.layers.iter() {
-            let layer = layer.clone();
-            let uri = uri.clone();
-            let tmp_path = tmp_path.clone();
-            tasks.push(tokio::spawn(async move {
-                let mut reader = layer.open(&uri).await?;
-                let blob_layer = format!(
-                    "{}.tar{}",
-                    layer.digest().split_once(":").unwrap().1,
-                    layer.media_type().compression().to_ext()
-                );
-                let mut blob_file = File::create(tmp_path.join(blob_layer.clone()))
-                    .await
-                    .context(error::FileSnafu)?;
-                Layer::copy(&mut reader, &mut blob_file, layer.size()).await?;
-                Ok(blob_layer)
-            }));
-        }
-        for result in join_all(tasks).await {
-            let result = result.unwrap();
-            manifest.layers.push(result?);
-        }
-        let manifest_bytes =
-            serde_json::to_string(&vec![manifest]).context(error::SerializeSnafu)?;
-        tokio::fs::write(tmp_dir.path().join("manifest.json"), manifest_bytes)
-            .await
-            .context(error::FileSnafu)?;
-        let mut archive = ArchiveBuilder::new(output);
-        archive
-            .append_dir_all(".", tmp_dir.path().to_path_buf())
-            .await
-            .context(error::ArchiveSnafu)?;
-        archive.finish().await.context(error::ArchiveSnafu)?;
-
-        Ok(())
-    }
-
-    /// Write this image out as a docker loadable tarball. This is NOT an oci archive and is primarily to be used with
-    /// docker/finch/podman/nerdctl load. This version will report as it fetches the image to indicatif progress bars.
-    #[cfg(all(feature = "compression", feature = "progress"))]
-    pub async fn to_tarball_progress<W>(
+    pub async fn to_tarball<W>(
         &self,
         uri: &Uri,
         output: W,
-        progress: &mut MultiProgress,
+        progress: SharedProgress,
     ) -> crate::Result<()>
     where
         W: AsyncWrite + Unpin + Send + 'static,
@@ -277,24 +184,27 @@ impl Image {
             .layers(vec![])
             .build();
         let tmp_dir = tempdir().context(error::TempSnafu)?;
-        let mut config_reader = self.config.open_progress(uri, progress).await?;
+        let mut config_reader = self.config.open(uri, progress.as_ref()).await?;
         let mut config_file = File::create(tmp_dir.path().join(self.config.digest()))
             .await
             .context(error::FileSnafu)?;
         Layer::copy(&mut config_reader, &mut config_file, self.config.size()).await?;
 
+        // Each spawned task gets its own clone of the Arc-backed
+        // SharedProgress; no `unsafe` lifetime extension required.
         let mut tasks: Vec<JoinHandle<crate::Result<String>>> = Vec::new();
         let tmp_path = tmp_dir.path().to_path_buf();
         for layer in self.layers.iter() {
             let layer = layer.clone();
             let uri = uri.clone();
             let tmp_path = tmp_path.clone();
-            let mut multi = progress.clone();
+            let progress = progress.clone();
             tasks.push(tokio::spawn(async move {
-                let mut reader = layer.open_progress(&uri, &mut multi).await?;
+                let parsed = Digest::parse(layer.digest())?;
+                let mut reader = layer.open(&uri, progress.as_ref()).await?;
                 let blob_layer = format!(
                     "{}.tar{}",
-                    layer.digest().split_once(":").unwrap().1,
+                    parsed.hex(),
                     layer.media_type().compression().to_ext()
                 );
                 let mut blob_file = File::create(tmp_path.join(blob_layer.clone()))
@@ -304,9 +214,13 @@ impl Image {
                 Ok(blob_layer)
             }));
         }
-        for result in join_all(tasks).await {
-            let result = result.unwrap();
-            manifest.layers.push(result?);
+        // try_join_all aborts on first error and returns the join error
+        // properly typed; #4 + #11.
+        let names = try_join_all(tasks)
+            .await
+            .context(error::JoinSnafu)?;
+        for name in names {
+            manifest.layers.push(name?);
         }
         let manifest_bytes =
             serde_json::to_string(&vec![manifest]).context(error::SerializeSnafu)?;
@@ -339,14 +253,16 @@ impl Image {
     /// Create a new config layer blob for an image
     pub async fn create_config(uri: &Uri, config: &Config) -> crate::Result<Layer> {
         let config_bytes = serde_json::to_vec(config).context(error::SerializeSnafu)?;
-        let mut writer = Layer::create(uri, &MediaType::Config, config_bytes.len(), None)
+        let mut writer = Layer::create(uri, &MediaType::Config, config_bytes.len(), None, None)
             .await?
-            .unwrap();
+            .context(error::InternalSnafu {
+                context: "Layer::create returned None for config blob",
+            })?;
         writer
             .write_all(config_bytes.as_slice())
             .await
             .context(error::LayerWriteSnafu)?;
-        writer.flush().await.context(error::LayerWriteSnafu)?;
+        writer.shutdown().await.context(error::LayerWriteSnafu)?;
         writer.layer().await
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,15 +1,15 @@
 use std::str::FromStr;
 
+use crate::digest::Digest;
 use crate::error;
 use crate::image::Image;
 use crate::layer::Layer;
 use crate::models::MediaType;
 use crate::models::Platform;
+use crate::progress::SharedProgress;
 use crate::uri::{Reference, Uri};
 use bon::Builder;
-use futures::future::join_all;
-#[cfg(feature = "progress")]
-use indicatif::MultiProgress;
+use futures::future::try_join_all;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use tempfile::tempdir;
@@ -143,13 +143,16 @@ impl Index {
         Ok(())
     }
 
-    /// Create an OCI tar archive that contains either all of the index images (if no platform provided)
-    /// or only the platforms specified
+    /// Create an OCI tar archive that contains either all of the index
+    /// images (if no platform provided) or only the platforms specified.
+    /// Pass a populated [`SharedProgress`] for progress reporting or
+    /// [`SharedProgress::none`] for silent operation.
     pub async fn to_oci<W>(
         &self,
         uri: &Uri,
         platform: Option<Platform>,
         output: W,
+        progress: SharedProgress,
     ) -> crate::Result<()>
     where
         W: AsyncWrite + Unpin + Send + 'static,
@@ -188,6 +191,7 @@ impl Index {
 
         // Now for every manifest we are working with we need to store it out
         for manifest in index.manifests.iter() {
+            let manifest_digest = Digest::parse(manifest.digest())?;
             let image_uri = Uri::builder()
                 .registry(uri.registry().clone())
                 .repository(uri.repository())
@@ -196,19 +200,15 @@ impl Index {
             let image = Image::fetch(&image_uri, manifest.platform().clone()).await?;
             // Write the image manifest as a blob
             let manifest_bytes = serde_json::to_string(&image).context(error::SerializeSnafu)?;
-            tokio::fs::write(
-                blob_dir.join(manifest.digest().strip_prefix("sha256:").unwrap()),
-                &manifest_bytes,
-            )
-            .await
-            .context(error::FileSnafu)?;
+            tokio::fs::write(blob_dir.join(manifest_digest.hex()), &manifest_bytes)
+                .await
+                .context(error::FileSnafu)?;
             // Copy the image config
-            let mut config_reader = image.config().open(uri).await?;
-            let mut config_file = File::create(
-                blob_dir.join(image.config().digest().strip_prefix("sha256:").unwrap()),
-            )
-            .await
-            .context(error::FileSnafu)?;
+            let config_digest = Digest::parse(image.config().digest())?;
+            let mut config_reader = image.config().open(uri, progress.as_ref()).await?;
+            let mut config_file = File::create(blob_dir.join(config_digest.hex()))
+                .await
+                .context(error::FileSnafu)?;
             Layer::copy(&mut config_reader, &mut config_file, image.config().size()).await?;
 
             let mut tasks: Vec<JoinHandle<crate::Result<()>>> = Vec::new();
@@ -216,124 +216,24 @@ impl Index {
                 let layer = layer.clone();
                 let uri = uri.clone();
                 let blob_dir = blob_dir.clone();
+                let progress = progress.clone();
                 tasks.push(tokio::spawn(async move {
-                    let mut reader = layer.open(&uri).await?;
-                    let mut blob_file = File::create(
-                        blob_dir.join(layer.digest().strip_prefix("sha256:").unwrap()),
-                    )
-                    .await
-                    .context(error::FileSnafu)?;
+                    let layer_digest = Digest::parse(layer.digest())?;
+                    let mut reader = layer.open(&uri, progress.as_ref()).await?;
+                    let mut blob_file = File::create(blob_dir.join(layer_digest.hex()))
+                        .await
+                        .context(error::FileSnafu)?;
                     Layer::copy(&mut reader, &mut blob_file, layer.size()).await?;
                     Ok(())
                 }));
             }
-            for result in join_all(tasks).await {
-                let result = result.context(error::LayerWaitSnafu)?;
-                result?;
-            }
-        }
-
-        let mut archive = ArchiveBuilder::new(output);
-        archive
-            .append_dir_all(".", tmp_dir.path().to_path_buf())
-            .await
-            .context(error::ArchiveSnafu)?;
-        archive.finish().await.context(error::ArchiveSnafu)?;
-
-        Ok(())
-    }
-
-    /// Create an OCI tar archive that contains either all of the index images (if no platform provided)
-    /// or only the platforms specified
-    #[cfg(feature = "progress")]
-    pub async fn to_oci_progress<W>(
-        &self,
-        uri: &Uri,
-        platform: Option<Platform>,
-        output: W,
-        multi: &mut MultiProgress,
-    ) -> crate::Result<()>
-    where
-        W: AsyncWrite + Unpin + Send + 'static,
-    {
-        let tmp_dir = tempdir().context(error::TempSnafu)?;
-        tokio::fs::write(
-            tmp_dir.path().join("oci-layout"),
-            r#"{ "imageLayoutVersion": "1.0.0" }"#,
-        )
-        .await
-        .context(error::FileSnafu)?;
-
-        let blob_dir = tmp_dir.path().join("blobs/sha256");
-        create_dir_all(&blob_dir)
-            .await
-            .context(error::DirectorySnafu)?;
-
-        // Start with ourselves for the index
-        let mut index = self.clone();
-        if let Some(platform) = platform {
-            // If we are selecting only a single platform then filter the manifests down
-            index.manifests = index
-                .manifests
-                .iter()
-                .filter(|x| x.platform() == Some(platform.clone()))
-                .cloned()
-                .collect::<Vec<Layer>>();
-            if index.manifests.is_empty() {
-                return error::IndexNoPlatformSnafu { platform }.fail();
-            }
-        }
-        let index_content = serde_json::to_string(&index).context(error::SerializeSnafu)?;
-        tokio::fs::write(tmp_dir.path().join("index.json"), &index_content)
-            .await
-            .context(error::FileSnafu)?;
-
-        // Now for every manifest we are working with we need to store it out
-        for manifest in index.manifests.iter() {
-            let image_uri = Uri::builder()
-                .registry(uri.registry().clone())
-                .repository(uri.repository())
-                .reference(Reference::from_str(manifest.digest())?)
-                .build();
-            let image = Image::fetch(&image_uri, manifest.platform().clone()).await?;
-            // Write the image manifest as a blob
-            let manifest_bytes = serde_json::to_string(&image).context(error::SerializeSnafu)?;
-            tokio::fs::write(
-                blob_dir.join(manifest.digest().strip_prefix("sha256:").unwrap()),
-                &manifest_bytes,
-            )
-            .await
-            .context(error::FileSnafu)?;
-            // Copy the image config
-            let mut config_reader = image.config().open_progress(uri, multi).await?;
-            let mut config_file = File::create(
-                blob_dir.join(image.config().digest().strip_prefix("sha256:").unwrap()),
-            )
-            .await
-            .context(error::FileSnafu)?;
-            Layer::copy(&mut config_reader, &mut config_file, image.config().size()).await?;
-
-            let mut tasks: Vec<JoinHandle<crate::Result<()>>> = Vec::new();
-            for layer in image.layers().iter() {
-                let layer = layer.clone();
-                let uri = uri.clone();
-                let mut multi = multi.clone();
-                let blob_dir = blob_dir.clone();
-                tasks.push(tokio::spawn(async move {
-                    let mut reader = layer.open_progress(&uri, &mut multi).await?;
-                    let mut blob_file = File::create(
-                        blob_dir.join(layer.digest().strip_prefix("sha256:").unwrap()),
-                    )
-                    .await
-                    .context(error::FileSnafu)?;
-                    Layer::copy(&mut reader, &mut blob_file, layer.size()).await?;
-                    Ok(())
-                }));
-            }
-            for result in join_all(tasks).await {
-                let result = result.context(error::LayerWaitSnafu)?;
-                result?;
-            }
+            // try_join_all aborts on first error and surfaces JoinErrors
+            // through the typed `Error::Join` variant (#4 + #11).
+            try_join_all(tasks)
+                .await
+                .context(error::JoinSnafu)?
+                .into_iter()
+                .collect::<crate::Result<Vec<_>>>()?;
         }
 
         let mut archive = ArchiveBuilder::new(output);

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,14 +1,13 @@
+use crate::digest::Digest as DigestRef;
 use crate::error;
 use crate::models::MediaType;
 use crate::models::Platform;
+use crate::progress::{NoopHandle, ProgressHandle, ProgressReporter};
 use crate::uri::{Reference, Uri};
 use bon::Builder;
 use bytes::Bytes;
-use cfg_if::cfg_if;
 use futures::FutureExt;
 use futures::future::BoxFuture;
-#[cfg(feature = "progress")]
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -18,6 +17,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio_util::io::StreamReader;
+use url::Url;
 
 /// Minimum chunk size for layer operations (5 MiB).
 const MIN_CHUNK_SIZE: usize = 5 * 1024 * 1024;
@@ -44,10 +44,11 @@ pub struct Layer {
 impl Layer {
     /// Perform a chunked copy of a layer from one reader to another.
     ///
-    /// Any time you want to interact with a layer in a registry, it is recommended
-    /// to use this method. While most OCI registry implementations do not need special
-    /// handling to make the chunks of data sent uniform, certain implementations
-    /// (i.e. ECR) work better when using more uniform chunked operations.
+    /// Any time you want to interact with a layer in a registry, it is
+    /// recommended to use this method. While most OCI registry
+    /// implementations do not need special handling to make the chunks of
+    /// data sent uniform, certain implementations (e.g. ECR) work better
+    /// when using more uniform chunked operations.
     pub async fn copy<'a, R, W>(
         reader: &'a mut R,
         writer: &'a mut W,
@@ -58,10 +59,8 @@ impl Layer {
         W: AsyncWrite + Unpin + ?Sized,
     {
         let mut index = 0;
-        // To determine the chunk size we do some math:
-        // 1. The chunk size should always be >= MIN_CHUNK_SIZE
-        // 2. The chunk size should always be <= MAX_CHUNK_SIZE
-        // 3. Ideally the chunk size should be 1/40th of the size of the layer (this lines up with how we print progress bar updates)
+        // Chunk size: clamped to [MIN_CHUNK_SIZE, MAX_CHUNK_SIZE]; aims for
+        // ~1/40th of the total to keep progress bars responsive.
         let chunk_size = (size / 40).clamp(MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
         while index < size {
             let read_size = min(chunk_size, size - index);
@@ -74,20 +73,27 @@ impl Layer {
                 .write_all(buffer.as_slice())
                 .await
                 .context(error::LayerWriteSnafu)?;
-            index += chunk_size;
+            // Advance by the bytes actually read this iteration, not the
+            // unclamped chunk size; otherwise the final partial chunk
+            // would over-count and we'd terminate the loop early on
+            // exact-size layers.
+            index += read_size;
         }
         Ok(())
     }
 
-    /// Create a new later on a registry and repository
+    /// Create a new layer in a registry. Returns `Ok(None)` if the registry
+    /// already contains a blob with the given digest.
+    ///
+    /// Pass `Some(reporter)` to attach progress; pass `None` to suppress.
     pub async fn create(
         uri: &Uri,
         media_type: &MediaType,
         size: usize,
         digest: Option<String>,
+        progress: Option<&dyn ProgressReporter>,
     ) -> crate::Result<Option<Writer>> {
         if let Some(digest) = digest.as_ref() {
-            // Check if the registry already has this layer
             trace!(target: "layer", "checking if a blob already exists with the digest: {digest}");
             if uri
                 .registry()
@@ -98,125 +104,85 @@ impl Layer {
                 return Ok(None);
             }
         }
-
-        cfg_if! {
-            if #[cfg(feature = "progress")] {
-                Ok(Some(Writer {
-                    uri: uri.clone(),
-                    index: 0,
-                    size,
-                    media_type: media_type.clone(),
-                    upload_url: None,
-                    active: None,
-                    digest: Sha256::new(),
-                    progress: None,
-                }))
-            } else {
-                Ok(Some(Writer {
-                    uri: uri.clone(),
-                    index: 0,
-                    size,
-                    media_type: media_type.clone(),
-                    upload_url: None,
-                    active: None,
-                    digest: Sha256::new(),
-                }))
+        let handle: Box<dyn ProgressHandle> = match progress {
+            Some(reporter) => {
+                let label = digest
+                    .as_ref()
+                    .and_then(|d| DigestRef::parse(d).ok())
+                    .map(|d| format!("blob {} ->", d.short(9)))
+                    .unwrap_or_else(|| "blob ->".to_string());
+                reporter.start(size as u64, &label)
             }
-        }
-    }
-
-    /// Create a new layer and report upload progress via an indicatif progress bar
-    #[cfg(feature = "progress")]
-    pub async fn create_progress(
-        uri: &Uri,
-        media_type: &MediaType,
-        prefix: &str,
-        size: u64,
-        multi: &mut MultiProgress,
-        digest: Option<String>,
-    ) -> crate::Result<Option<Writer>> {
-        let bar = multi.add(ProgressBar::new(size));
-        bar.set_style(
-            ProgressStyle::with_template(
-                "-> {prefix}: [{elapsed_precise}] {bar:40.cyan/blue} {msg} ({binary_bytes:>7}/{binary_total_bytes:7})",
-            )
-            .unwrap()
-            .progress_chars("##-"),
-        );
-        bar.set_prefix(prefix.to_string());
-        if let Some(digest) = digest.as_ref() {
-            // Check if the registry already has this layer
-            trace!(target: "layer", "checking if a blob already exists with the digest: {digest}");
-            if uri
-                .registry()
-                .check_blob(uri.repository(), digest.as_str())
-                .await?
-            {
-                debug!(target: "layer", "blob already exists with the digest: {digest}");
-                bar.finish_with_message("already exists");
-                return Ok(None);
-            }
-        }
-
+            None => Box::new(NoopHandle),
+        };
         Ok(Some(Writer {
             uri: uri.clone(),
-            index: 0,
-            size: size as usize,
+            size,
             media_type: media_type.clone(),
-            upload_url: None,
-            active: None,
+            state: WriterState::Initial,
             digest: Sha256::new(),
-            progress: Some(bar),
+            written: 0,
+            buffer: Vec::new(),
+            progress: handle,
         }))
     }
 
-    /// Open a layer blob for reading
-    pub async fn open(&self, uri: &Uri) -> crate::Result<Reader> {
-        let (reader, _) = uri
-            .registry()
-            .fetch_blob(uri.repository(), self.digest.as_str())
-            .await?;
-        let reader = StreamReader::new(reader);
-        Ok(Reader::new(reader))
-    }
-
-    /// Open a layer blob for reading and report progress to an indicatif progress bar
-    #[cfg(feature = "progress")]
-    pub async fn open_progress(
+    /// Open a layer blob for reading. Pass `Some(reporter)` to attach
+    /// progress; pass `None` to suppress.
+    pub async fn open(
         &self,
         uri: &Uri,
-        multi: &mut MultiProgress,
+        progress: Option<&dyn ProgressReporter>,
     ) -> crate::Result<Reader> {
-        let prefix = &self.digest.strip_prefix("sha256:").unwrap()[0..9];
-        let (reader, _) = uri
+        let (stream, content_length) = uri
             .registry()
             .fetch_blob(uri.repository(), self.digest.as_str())
             .await?;
-        let bar = multi.add(ProgressBar::new(self.size as u64));
-        bar.set_style(
-            ProgressStyle::with_template(
-                "<- {prefix}: [{elapsed_precise}] {bar:40.cyan/blue} {msg} ({binary_bytes:>7}/{binary_total_bytes:7})",
-            )
-            .unwrap()
-            .progress_chars("##-"),
-        );
-        bar.set_prefix(format!("blob {prefix}"));
-        let reader = StreamReader::new(reader);
-        Ok(Reader::new_progress(reader, bar))
+        // #18: validate the registry's reported size up front when present.
+        let expected = self.size as u64;
+        if content_length != 0 && content_length != expected {
+            return error::LayerSizeMismatchSnafu {
+                expected: expected as usize,
+                actual: content_length as usize,
+            }
+            .fail();
+        }
+        let handle: Box<dyn ProgressHandle> = match progress {
+            Some(reporter) => {
+                let label = DigestRef::parse(&self.digest)
+                    .map(|d| format!("blob {} <-", d.short(9)))
+                    .unwrap_or_else(|_| "blob <-".to_string());
+                reporter.start(expected, &label)
+            }
+            None => Box::new(NoopHandle),
+        };
+        let stream_reader = StreamReader::new(stream);
+        Ok(Reader::new(
+            stream_reader,
+            handle,
+            Some(self.digest.clone()),
+            Some(self.size),
+        ))
     }
 
-    /// Open a layer for reading at the specified uri
+    /// Open a layer for reading at the specified URI (used for raw blob
+    /// access without a parent layer descriptor).
     pub async fn open_uri(uri: &Uri) -> crate::Result<Reader> {
         ensure!(
             matches!(uri.reference(), Reference::Digest { .. }),
             error::DirectLoadBlobSnafu { uri: uri.clone() }
         );
         let digest = uri.reference().to_string();
-        let (reader, _) = uri
+        let (stream, _size) = uri
             .registry()
             .fetch_blob(uri.repository(), digest.as_str())
             .await?;
-        Ok(Reader::new(StreamReader::new(reader)))
+        Ok(Reader::new(
+            StreamReader::new(stream),
+            Box::new(NoopHandle),
+            None,
+            None,
+        ))
     }
 
     /// Media type of the layer
@@ -247,52 +213,45 @@ impl Layer {
     }
 }
 
-/// Layer `AsyncRead` implementation with optional progress reporting.
-///
-/// Automatically reports to a progress bar if provided and the progress
-/// feature is enabled. It can also decompress the contents of the reader.
+/// Layer `AsyncRead` implementation with progress reporting and optional
+/// digest/size verification.
 pub struct Reader {
-    inner: Pin<Box<dyn AsyncRead>>,
-    #[cfg(feature = "progress")]
-    progress: Option<ProgressBar>,
+    inner: Pin<Box<dyn AsyncRead + Send + Sync>>,
+    progress: Box<dyn ProgressHandle>,
+    /// Expected digest of the streamed bytes; verified at EOF when set.
+    expected_digest: Option<String>,
+    expected_size: Option<usize>,
+    hasher: Sha256,
+    bytes_read: usize,
+    /// Set to true after we've validated the final digest at EOF, so we
+    /// don't run validation twice.
+    finalized: bool,
 }
-
-#[cfg(feature = "progress")]
-impl Drop for Reader {
-    fn drop(&mut self) {
-        if let Some(progress) = self.progress.as_mut() {
-            progress.finish_with_message("done");
-        }
-    }
-}
-
-unsafe impl Send for Reader {}
-unsafe impl Sync for Reader {}
 
 impl Reader {
-    /// Create a base reader
-    pub fn new(inner: impl AsyncRead + 'static) -> Self {
-        cfg_if! {
-            if #[cfg(feature = "progress")] {
-                Self {
-                    inner: Box::pin(inner),
-                    progress: None,
-                }
-            } else {
-                Self {
-                    inner: Box::pin(inner),
-                }
-            }
-        }
-    }
-
-    /// Create a reader that will report progress to an indicatif progress bar
-    #[cfg(feature = "progress")]
-    pub fn new_progress(inner: impl AsyncRead + 'static, progress: ProgressBar) -> Self {
+    /// Create a new reader. The progress handle is always present; pass
+    /// [`Box::new(NoopHandle)`] when progress is not desired.
+    pub fn new(
+        inner: impl AsyncRead + Send + Sync + 'static,
+        progress: Box<dyn ProgressHandle>,
+        expected_digest: Option<String>,
+        expected_size: Option<usize>,
+    ) -> Self {
         Self {
             inner: Box::pin(inner),
-            progress: Some(progress),
+            progress,
+            expected_digest,
+            expected_size,
+            hasher: Sha256::new(),
+            bytes_read: 0,
+            finalized: false,
         }
+    }
+}
+
+impl Drop for Reader {
+    fn drop(&mut self) {
+        self.progress.finish();
     }
 }
 
@@ -303,69 +262,344 @@ impl AsyncRead for Reader {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         let this = self.get_mut();
+        let before = buf.filled().len();
         match this.inner.as_mut().poll_read(cx, buf) {
             Poll::Ready(Ok(())) => {
-                cfg_if! {
-                    if #[cfg(feature = "progress")] {
-                        if let Some(bar) = this.progress.as_mut() && buf.remaining() == 0 {
-                            bar.inc(buf.filled().len() as u64);
+                let after = buf.filled().len();
+                let delta = after - before;
+                if delta > 0 {
+                    let new_chunk = &buf.filled()[before..after];
+                    this.hasher.update(new_chunk);
+                    this.bytes_read += delta;
+                    if let Some(expected) = this.expected_size
+                        && this.bytes_read > expected
+                    {
+                        return Poll::Ready(Err(std::io::Error::other(format!(
+                            "registry returned more bytes than declared (expected {expected}, got {})",
+                            this.bytes_read
+                        ))));
+                    }
+                    this.progress.inc(delta as u64);
+                } else if !this.finalized {
+                    // EOF: validate digest and final size.
+                    this.finalized = true;
+                    if let Some(expected) = this.expected_size
+                        && this.bytes_read != expected
+                    {
+                        return Poll::Ready(Err(std::io::Error::other(format!(
+                            "short layer read (expected {expected}, got {})",
+                            this.bytes_read
+                        ))));
+                    }
+                    if let Some(expected) = this.expected_digest.as_ref() {
+                        let computed = format!(
+                            "sha256:{}",
+                            base16::encode_lower(this.hasher.clone().finalize().as_slice())
+                        );
+                        if computed != *expected {
+                            return Poll::Ready(Err(std::io::Error::other(format!(
+                                "layer digest mismatch: expected {expected}, computed {computed}"
+                            ))));
                         }
                     }
                 }
                 Poll::Ready(Ok(()))
             }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
+            other => other,
         }
     }
 }
 
 /// `AsyncWrite` implementation that writes a blob to a registry.
 ///
-/// Automatically handles chunked upload versus single upload based on the
-/// size of the blob. Construction of this type is done by the Layer create methods.
+/// The state machine progresses Initial → Starting → Idle ↔ Uploading →
+/// Finishing → Done. Hash and offset state advance only after the registry
+/// confirms each chunk, so a failed PATCH does not leave callers with a
+/// digest computed from bytes that aren't actually durable.
 pub struct Writer {
     uri: Uri,
-
     media_type: MediaType,
-    upload_url: Option<String>,
-    index: usize,
+    /// Total expected blob size (from layer descriptor).
     size: usize,
+    /// Bytes the registry has confirmed accepted.
+    written: usize,
     digest: Sha256,
-    #[cfg(feature = "progress")]
-    progress: Option<ProgressBar>,
-    active: Option<Operation>,
+    state: WriterState,
+    /// Buffer of bytes that have been logically accepted from the caller
+    /// but not yet flushed/uploaded.
+    buffer: Vec<u8>,
+    progress: Box<dyn ProgressHandle>,
 }
 
-/// Represents the current state of an async write operation.
-enum Operation {
-    Error(BoxFuture<'static, Result<Bytes, reqwest::Error>>),
-    Start(BoxFuture<'static, crate::Result<Response>>),
-    Upload(BoxFuture<'static, crate::Result<Response>>),
+enum WriterState {
+    /// No upload has been initiated yet.
+    Initial,
+    /// POST {repo}/blobs/uploads/ is in flight to start the upload session.
+    Starting(BoxFuture<'static, crate::Result<Response>>),
+    /// We have an upload URL and are buffering bytes in `buffer`.
+    Idle { upload_url: Url },
+    /// PATCH is in flight; on success advance offset and update upload URL.
+    Uploading {
+        fut: BoxFuture<'static, crate::Result<Response>>,
+        chunk_len: usize,
+    },
+    /// PUT (final) is in flight. `pending_advance` is the number of bytes
+    /// in this final body that have not yet been credited to `written` or to
+    /// the progress bar; we advance both only after the registry confirms.
+    Finishing {
+        fut: BoxFuture<'static, crate::Result<Response>>,
+        pending_advance: usize,
+    },
+    /// Drained successfully and the blob is durable.
+    Done,
+    /// Sticky failure state; further polls return the saved error string.
+    Failed(String),
 }
 
 impl Writer {
-    /// Construct a layer object out of this writer, this also will signal a finish to the progress
-    /// bar in this writer if the feature is being used.
+    /// Finalize this writer into a [`Layer`]. Must be called after
+    /// `shutdown()` has returned `Ready(Ok)`.
     pub async fn layer(&mut self) -> crate::Result<Layer> {
-        let digest_bytes = self.digest.clone().finalize();
-        let digest = base16::encode_lower(&digest_bytes);
-        let digest = format!("sha256:{}", digest.clone());
-
-        cfg_if! {
-            if #[cfg(feature = "progress")] {
-                if let Some(bar) = self.progress.as_mut() {
-                    bar.finish_with_message("done");
-                }
-            }
-
+        if !matches!(self.state, WriterState::Done) {
+            return Err(error::Error::LayerWrite {
+                source: std::io::Error::other("writer.layer() called before shutdown"),
+            });
         }
+        let digest_bytes = self.digest.clone().finalize();
+        let digest = format!("sha256:{}", base16::encode_lower(&digest_bytes));
+        self.progress.finish();
         Ok(Layer {
             media_type: self.media_type.clone(),
-            digest: digest.clone(),
-            size: self.index,
+            digest,
+            size: self.written,
             platform: None,
         })
+    }
+
+    fn fail<E: std::fmt::Display>(&mut self, e: E) -> std::io::Error {
+        let s = e.to_string();
+        self.state = WriterState::Failed(s.clone());
+        std::io::Error::other(s)
+    }
+
+    /// Returns true if the buffer is large enough to flush eagerly.
+    fn buffer_ready_to_flush(&self) -> bool {
+        self.buffer.len() >= MIN_CHUNK_SIZE
+    }
+
+    /// Drive an in-flight upload future. On success, advance offsets and
+    /// transition back to `Idle`. On failure, transition to `Failed`.
+    fn poll_uploading(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let WriterState::Uploading { fut, chunk_len } = &mut self.state else {
+            unreachable!("poll_uploading called outside Uploading state");
+        };
+        match fut.poll_unpin(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(response)) => {
+                let chunk_len = *chunk_len;
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let err = self.fail(format!("registry rejected chunk: {status}"));
+                    return Poll::Ready(Err(err));
+                }
+                // Resolve next upload URL from Location.
+                let next_url = match crate::client::extract_location(&response, &self.current_url())
+                {
+                    Ok(u) => u,
+                    Err(e) => {
+                        let err = self.fail(e);
+                        return Poll::Ready(Err(err));
+                    }
+                };
+                self.written += chunk_len;
+                self.progress.inc(chunk_len as u64);
+                self.state = WriterState::Idle {
+                    upload_url: next_url,
+                };
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                let err = self.fail(e);
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+
+    fn poll_finishing(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let WriterState::Finishing {
+            fut,
+            pending_advance,
+        } = &mut self.state
+        else {
+            unreachable!("poll_finishing called outside Finishing state");
+        };
+        match fut.poll_unpin(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(response)) => {
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let err = self.fail(format!("registry rejected blob finalize: {status}"));
+                    return Poll::Ready(Err(err));
+                }
+                // Only credit the durable bytes once the registry confirms
+                // the final PUT succeeded.
+                let advance = *pending_advance;
+                self.written += advance;
+                self.progress.inc(advance as u64);
+                self.state = WriterState::Done;
+                self.progress.finish();
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                let err = self.fail(e);
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+
+    fn poll_starting(&mut self, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        let WriterState::Starting(fut) = &mut self.state else {
+            unreachable!("poll_starting called outside Starting state");
+        };
+        match fut.poll_unpin(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(response)) => {
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let err = self.fail(format!("registry rejected upload start: {status}"));
+                    return Poll::Ready(Err(err));
+                }
+                let url = match crate::client::extract_location(&response, &self.current_url()) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        let err = self.fail(e);
+                        return Poll::Ready(Err(err));
+                    }
+                };
+                self.state = WriterState::Idle { upload_url: url };
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(e)) => {
+                let err = self.fail(e);
+                Poll::Ready(Err(err))
+            }
+        }
+    }
+
+    fn current_url(&self) -> Url {
+        // Best-effort base URL for resolving Location headers; we use the
+        // original registry URL because that's what reqwest sent the
+        // request to. Errors here mean the registry URI itself is broken,
+        // which is fatal anyway.
+        self.uri
+            .registry()
+            .url()
+            .unwrap_or_else(|_| Url::parse("http://invalid.local/").expect("invariant"))
+    }
+
+    /// Kick off a PATCH for the buffered chunk. Caller guarantees that
+    /// `self.state` is `Idle` and the buffer is non-empty.
+    fn launch_patch(&mut self) {
+        let WriterState::Idle { upload_url } =
+            std::mem::replace(&mut self.state, WriterState::Done)
+        else {
+            unreachable!("launch_patch called outside Idle state");
+        };
+        let chunk = std::mem::take(&mut self.buffer);
+        let chunk_len = chunk.len();
+        // Hash the durable bytes; offset advance happens after the
+        // registry confirms the PATCH succeeded (#15).
+        self.digest.update(&chunk);
+        let bytes = Bytes::from(chunk);
+        let start = self.written;
+        let end = start + chunk_len;
+        let client = self.uri.registry().client.clone();
+        let upload_url_for_fut = upload_url.clone();
+        let fut = async move {
+            client
+                .upload_part(upload_url_for_fut, bytes, start, end)
+                .await
+        }
+        .boxed();
+        self.state = WriterState::Uploading { fut, chunk_len };
+    }
+
+    /// Kick off the final PUT. Caller guarantees Idle state.
+    fn launch_finish(&mut self) {
+        let WriterState::Idle { upload_url } =
+            std::mem::replace(&mut self.state, WriterState::Done)
+        else {
+            unreachable!("launch_finish called outside Idle state");
+        };
+        let chunk = std::mem::take(&mut self.buffer);
+        let chunk_len = chunk.len();
+        if chunk_len > 0 {
+            self.digest.update(&chunk);
+        }
+        let digest_bytes = self.digest.clone().finalize();
+        let digest = format!("sha256:{}", base16::encode_lower(&digest_bytes));
+        let bytes = Bytes::from(chunk);
+        let start = self.written;
+        let end = start + chunk_len;
+        let client = self.uri.registry().client.clone();
+        let fut = async move {
+            client
+                .finish_blob_upload(upload_url, bytes, digest, start, end)
+                .await
+        }
+        .boxed();
+        // Defer offset/progress advance to poll_finishing on success so that
+        // failed finalize attempts don't leave a corrupt accounting state.
+        self.state = WriterState::Finishing {
+            fut,
+            pending_advance: chunk_len,
+        };
+    }
+
+    /// Kick off a monolithic POST (single-shot upload). Caller guarantees
+    /// the buffer holds the entire blob and we are in Initial state.
+    fn launch_monolithic_post(&mut self) {
+        let chunk = std::mem::take(&mut self.buffer);
+        let chunk_len = chunk.len();
+        self.digest.update(&chunk);
+        let digest_bytes = self.digest.clone().finalize();
+        let digest = format!("sha256:{}", base16::encode_lower(&digest_bytes));
+        let bytes = Bytes::from(chunk);
+        let registry_url = match self.uri.registry().url() {
+            Ok(u) => u,
+            Err(e) => {
+                self.state = WriterState::Failed(e.to_string());
+                return;
+            }
+        };
+        let repository = self.uri.repository().clone();
+        let client = self.uri.registry().client.clone();
+        let fut = async move {
+            client
+                .post_blob(registry_url, repository, bytes, digest)
+                .await
+        }
+        .boxed();
+        // Defer offset/progress advance until poll_finishing confirms success.
+        self.state = WriterState::Finishing {
+            fut,
+            pending_advance: chunk_len,
+        };
+    }
+
+    /// Kick off a session-start POST. Caller guarantees Initial state.
+    fn launch_start(&mut self) {
+        let registry_url = match self.uri.registry().url() {
+            Ok(u) => u,
+            Err(e) => {
+                self.state = WriterState::Failed(e.to_string());
+                return;
+            }
+        };
+        let repository = self.uri.repository().clone();
+        let client = self.uri.registry().client.clone();
+        let fut = async move { client.start_upload(registry_url, repository).await }.boxed();
+        self.state = WriterState::Starting(fut);
     }
 }
 
@@ -376,152 +610,207 @@ impl AsyncWrite for Writer {
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
         let this = self.get_mut();
-        if let Some(operation) = this.active.as_mut() {
-            match operation {
-                Operation::Start(poll) => match poll.poll_unpin(cx) {
-                    Poll::Ready(Ok(response)) => {
-                        trace!(target: "layer", "RESPONSE {:?}", response);
-                        this.active = None;
-                        if !response.status().is_success() {
-                            this.active = Some(Operation::Error(Box::pin(response.bytes())));
-                            cx.waker().wake_by_ref();
-                            return Poll::Pending;
-                        }
-                        this.upload_url = response
-                            .headers()
-                            .get("Location")
-                            .and_then(|x| x.to_str().ok())
-                            .map(|x| x.to_string());
-                        trace!(target: "layer", "registry provided upload_url = {:?}", this.upload_url);
-                        // We return pending here with a wake to ensure we write the first buf
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
-                    }
-                    Poll::Ready(Err(e)) => Poll::Ready(Err(std::io::Error::other(e))),
-                    Poll::Pending => {
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
-                    }
+        // Drive any pending async work to readiness first; that may
+        // transition us back to Idle so we can accept more bytes.
+        loop {
+            match &this.state {
+                WriterState::Failed(reason) => {
+                    return Poll::Ready(Err(std::io::Error::other(reason.clone())));
+                }
+                WriterState::Done => {
+                    return Poll::Ready(Err(std::io::Error::other(
+                        "writer is closed; further writes are rejected",
+                    )));
+                }
+                WriterState::Starting(_) => match this.poll_starting(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                 },
-                Operation::Upload(poll) => match poll.poll_unpin(cx) {
-                    Poll::Ready(Ok(response)) => {
-                        trace!(target: "layer", "RESPONSE {:?}", response);
-                        this.active = None;
-                        if response.status().is_success() {
-                            cfg_if! {
-                                if #[cfg(feature = "progress")] {
-                                    if let Some(bar) = this.progress.as_mut() {
-                                        bar.inc(buf.len() as u64);
-                                    }
-                                }
-                            }
-                            Poll::Ready(Ok(buf.len()))
-                        } else {
-                            this.active = Some(Operation::Error(Box::pin(response.bytes())));
-                            cx.waker().wake_by_ref();
-                            Poll::Pending
-                        }
-                    }
-                    Poll::Ready(Err(e)) => Poll::Ready(Err(std::io::Error::other(e))),
-                    Poll::Pending => {
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
-                    }
+                WriterState::Uploading { .. } => match this.poll_uploading(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                 },
-                Operation::Error(poll) => match poll.poll_unpin(cx) {
-                    Poll::Ready(Ok(response)) => {
-                        this.active = None;
-                        Poll::Ready(Err(std::io::Error::other(String::from_utf8_lossy(
-                            response.as_ref(),
-                        ))))
-                    }
-                    Poll::Ready(Err(e)) => Poll::Ready(Err(std::io::Error::other(e))),
-                    Poll::Pending => {
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
-                    }
+                WriterState::Finishing { .. } => match this.poll_finishing(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
                 },
+                WriterState::Initial | WriterState::Idle { .. } => break,
             }
-        } else if let Some(upload_url) = this.upload_url.as_ref() {
-            if this.index + buf.len() >= this.size {
-                // If our position plus the buffer we want to write is the end we should
-                // finish the upload
-                this.digest.update(buf);
-                let hash = this.digest.clone().finalize();
-                let digest = base16::encode_lower(hash.as_slice());
-                let url = this.uri.registry().url().map_err(std::io::Error::other)?;
-                this.active = Some(Operation::Upload(Box::pin(
-                    this.uri.registry().client.clone().finish_blob_upload(
-                        url,
-                        upload_url.clone(),
-                        Bytes::from_owner(buf.to_vec()),
-                        format!("sha256:{digest}"),
-                        this.index,
-                        this.size,
-                    ),
-                )));
-                this.index += buf.len();
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            } else {
-                // Otherwise we should send what we have as a patch
-                let url = this.uri.registry().url().map_err(std::io::Error::other)?;
-                this.active = Some(Operation::Upload(Box::pin(
-                    this.uri.registry().client.clone().upload_part(
-                        url,
-                        upload_url.clone(),
-                        Bytes::from_owner(buf.to_vec()),
-                        this.index,
-                        this.index + buf.len(),
-                    ),
-                )));
-                this.index += buf.len();
-                this.digest.update(buf);
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-        } else if buf.len() == this.size {
-            // If we haven't started an upload and the passed buffer is equal to the size of the layer
-            // we are writing, we can send a single post upload
-            this.digest.update(buf);
-            let hash = this.digest.clone().finalize();
-            let digest = base16::encode_lower(hash.as_slice());
-            let url = this.uri.registry().url().map_err(std::io::Error::other)?;
-            this.active = Some(Operation::Upload(Box::pin(
-                this.uri.registry().client.clone().post_blob(
-                    url,
-                    this.uri.repository().clone(),
-                    Bytes::from_owner(buf.to_vec()),
-                    format!("sha256:{digest}"),
-                ),
-            )));
-            this.index = buf.len();
-            cx.waker().wake_by_ref();
-            Poll::Pending
-        } else {
-            // If we have not started an upload we should do so now
-            let url = this.uri.registry().url().map_err(std::io::Error::other)?;
-            this.active = Some(Operation::Start(Box::pin(
-                this.uri
-                    .registry()
-                    .client
-                    .clone()
-                    .start_upload(url, this.uri.repository().clone()),
-            )));
-            this.index = 0;
-            cx.waker().wake_by_ref();
-            Poll::Pending
         }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        // Bound how much we accept this call so the buffer doesn't grow
+        // unbounded in one shot; the caller will simply be invoked again.
+        let to_take = buf.len().min(MAX_CHUNK_SIZE);
+        this.buffer.extend_from_slice(&buf[..to_take]);
+        // Decide whether to fire an upload now or accept and yield.
+        match this.state {
+            WriterState::Initial => {
+                // Have we now buffered the full blob? Then a single POST
+                // suffices. Otherwise we need a session-start.
+                if this.buffer.len() >= this.size && this.size > 0 {
+                    this.launch_monolithic_post();
+                } else if this.buffer_ready_to_flush() {
+                    this.launch_start();
+                }
+            }
+            WriterState::Idle { .. } => {
+                if this.buffer_ready_to_flush() {
+                    this.launch_patch();
+                }
+            }
+            _ => unreachable!("only Initial/Idle reachable post-drive"),
+        }
+        Poll::Ready(Ok(to_take))
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        let this = self.get_mut();
+        loop {
+            match &this.state {
+                WriterState::Failed(reason) => {
+                    return Poll::Ready(Err(std::io::Error::other(reason.clone())));
+                }
+                WriterState::Done => return Poll::Ready(Ok(())),
+                WriterState::Starting(_) => match this.poll_starting(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Uploading { .. } => match this.poll_uploading(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Finishing { .. } => match this.poll_finishing(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Initial | WriterState::Idle { .. } => return Poll::Ready(Ok(())),
+            }
+        }
     }
 
     fn poll_shutdown(
         self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        Poll::Ready(Ok(()))
+        let this = self.get_mut();
+        loop {
+            match &this.state {
+                WriterState::Failed(reason) => {
+                    return Poll::Ready(Err(std::io::Error::other(reason.clone())));
+                }
+                WriterState::Done => return Poll::Ready(Ok(())),
+                WriterState::Starting(_) => match this.poll_starting(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Uploading { .. } => match this.poll_uploading(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Finishing { .. } => match this.poll_finishing(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(())) => continue,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                },
+                WriterState::Initial => {
+                    // No upload was started. Either the blob fit in the
+                    // buffer (single POST) or we have an empty blob.
+                    if !this.buffer.is_empty() {
+                        this.launch_monolithic_post();
+                        continue;
+                    }
+                    // Empty blob: no chunks to send. Mark Done.
+                    this.state = WriterState::Done;
+                    return Poll::Ready(Ok(()));
+                }
+                WriterState::Idle { .. } => {
+                    // Drain any remaining buffer through PUT.
+                    this.launch_finish();
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    /// Reader that returns short reads; verifies `Layer::copy` advances by
+    /// the actually-read amount, not by the unclamped chunk size.
+    struct ShortReader {
+        data: Vec<u8>,
+        pos: usize,
+    }
+
+    impl AsyncRead for ShortReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let this = self.get_mut();
+            let remaining = this.data.len() - this.pos;
+            // Always serve in tiny pieces.
+            let take = remaining.min(7).min(buf.remaining());
+            buf.put_slice(&this.data[this.pos..this.pos + take]);
+            this.pos += take;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn copy_handles_short_reads() {
+        let data = vec![0xABu8; 31];
+        let mut src = ShortReader {
+            data: data.clone(),
+            pos: 0,
+        };
+        let mut dst = Vec::new();
+        // Use a small "size" to force tight loop iterations.
+        Layer::copy(&mut src, &mut dst, data.len()).await.unwrap();
+        assert_eq!(dst, data);
+    }
+
+    #[tokio::test]
+    async fn reader_finalizes_digest_on_eof_when_present() {
+        // Empty stream with empty-data sha256.
+        let empty_digest =
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        let mut r = Reader::new(
+            tokio::io::empty(),
+            Box::new(NoopHandle),
+            Some(empty_digest.to_string()),
+            Some(0),
+        );
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).await.unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[tokio::test]
+    async fn reader_detects_digest_mismatch() {
+        let bad_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+        let mut r = Reader::new(
+            tokio::io::empty(),
+            Box::new(NoopHandle),
+            Some(bad_digest.to_string()),
+            Some(0),
+        );
+        let mut out = Vec::new();
+        let err = r.read_to_end(&mut out).await.unwrap_err();
+        assert!(err.to_string().contains("digest mismatch"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub(crate) mod client;
 /// Layer decompression utilities.
 #[cfg(feature = "compression")]
 pub mod compression;
+/// Digest representation and parsing.
+pub mod digest;
 /// Error types for the crate.
 pub mod error;
 /// Image manifest handling.
@@ -15,6 +17,8 @@ pub mod index;
 pub mod layer;
 /// OCI specification model types.
 pub mod models;
+/// Optional progress reporting trait.
+pub mod progress;
 /// Registry client and operations.
 pub mod registry;
 /// Repository operations.

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,9 +1,11 @@
 use base64::Engine;
 use bon::Builder;
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use snafu::{OptionExt, ResultExt};
 use std::env::consts;
+use std::str::FromStr;
 use std::{collections::HashMap, fmt};
 
 /// Handles all the supported media type enumerations by this tool.
@@ -184,13 +186,33 @@ impl Default for Platform {
     }
 }
 
-impl From<String> for Platform {
-    fn from(value: String) -> Self {
-        let (os, architecture) = value.split_once("/").unwrap();
-        Self {
+impl FromStr for Platform {
+    type Err = crate::error::Error;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let (os, architecture) = value.split_once('/').context(
+            crate::error::InvalidPlatformFormatSnafu {
+                value: value.to_string(),
+            },
+        )?;
+        snafu::ensure!(
+            !os.is_empty() && !architecture.is_empty(),
+            crate::error::InvalidPlatformEmptySnafu {
+                value: value.to_string(),
+            }
+        );
+        Ok(Self {
             architecture: architecture.to_string(),
             os: os.to_string(),
-        }
+        })
+    }
+}
+
+impl TryFrom<String> for Platform {
+    type Error = crate::error::Error;
+
+    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
+        value.parse()
     }
 }
 
@@ -232,7 +254,8 @@ pub struct Config {
 #[serde(rename_all = "snake_case")]
 pub struct History {
     #[builder(into)]
-    pub created: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<Timestamp>,
     #[builder(into)]
     pub created_by: String,
     #[builder(into)]
@@ -251,7 +274,8 @@ pub struct ImageConfig {
     #[builder(into)]
     pub config: Config,
     #[builder(into)]
-    pub created: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created: Option<Timestamp>,
     #[builder(into)]
     pub history: Vec<History>,
     #[builder(into)]
@@ -380,22 +404,39 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn parse(value: DockerAuth) -> Option<Self> {
+    /// Build a token from a parsed docker auth file entry.
+    ///
+    /// Returns `Ok(None)` when the entry has neither an identity token nor
+    /// a basic auth blob. Returns `Err(InvalidAuth)` when the basic auth
+    /// blob is present but cannot be decoded as `username:password`. This
+    /// replaces the previous `unwrap`-based implementation that would
+    /// panic on malformed config files (#9).
+    pub fn parse(value: DockerAuth) -> Result<Option<Self>, crate::error::Error> {
         if let Some(identitytoken) = value.identitytoken {
-            Some(Self::Bearer(identitytoken))
-        } else if let Some(auth) = value.auth {
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(auth)
-                .unwrap();
-            let decoded = String::from_utf8_lossy(&decoded);
-            let (username, password) = decoded.split_once(':').unwrap();
-            Some(Self::Basic {
-                username: username.to_string(),
-                password: password.to_string(),
-            })
-        } else {
-            None
+            return Ok(Some(Self::Bearer(identitytoken)));
         }
+        let Some(auth) = value.auth else {
+            return Ok(None);
+        };
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(auth)
+            .context(crate::error::AuthBase64DecodeSnafu {
+                context: "docker auth",
+            })?;
+        let decoded =
+            std::str::from_utf8(&decoded).context(crate::error::AuthUtf8Snafu {
+                context: "docker auth",
+            })?;
+        let (username, password) =
+            decoded
+                .split_once(':')
+                .context(crate::error::AuthMissingSeparatorSnafu {
+                    context: "docker auth",
+                })?;
+        Ok(Some(Self::Basic {
+            username: username.to_string(),
+            password: password.to_string(),
+        }))
     }
 }
 
@@ -410,4 +451,43 @@ pub struct DockerConfig {
 pub struct DockerAuth {
     pub auth: Option<String>,
     pub identitytoken: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_parses_valid() {
+        let p: Platform = "linux/amd64".parse().expect("should parse");
+        assert_eq!(p.os, "linux");
+        assert_eq!(p.architecture, "amd64");
+    }
+
+    #[test]
+    fn platform_rejects_missing_separator() {
+        let err = "linux".parse::<Platform>().expect_err("should fail");
+        assert!(matches!(
+            err,
+            crate::error::Error::InvalidPlatformFormat { .. }
+        ));
+    }
+
+    #[test]
+    fn platform_rejects_empty_components() {
+        assert!(matches!(
+            "/amd64".parse::<Platform>(),
+            Err(crate::error::Error::InvalidPlatformEmpty { .. })
+        ));
+        assert!(matches!(
+            "linux/".parse::<Platform>(),
+            Err(crate::error::Error::InvalidPlatformEmpty { .. })
+        ));
+    }
+
+    #[test]
+    fn platform_try_from_string_round_trips_display() {
+        let p = Platform::try_from("linux/arm64".to_string()).unwrap();
+        assert_eq!(p.to_string(), "linux/arm64");
+    }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,130 @@
+//! Optional progress reporting for long running blob operations.
+//!
+//! The library exposes a small object-safe trait so callers can plug in any
+//! progress UI (e.g. `indicatif`) without forcing that dependency on every
+//! consumer. Pass `None` anywhere a `Option<&dyn ProgressReporter>` is
+//! accepted to disable progress reporting entirely. When a reporter must
+//! cross a `tokio::spawn` boundary, pass an [`std::sync::Arc`] wrapped
+//! version via [`SharedProgress`].
+
+use std::sync::Arc;
+
+/// A handle to an in-flight progress bar / counter for a single operation.
+///
+/// Implementations should treat `Drop` as the completion signal so callers do
+/// not need to remember to finish the bar manually.
+pub trait ProgressHandle: Send + Sync {
+    /// Advance the bar by the given number of bytes.
+    fn inc(&self, delta: u64);
+
+    /// Update the bar's message text. Implementations may ignore this.
+    fn set_message(&self, _message: &str) {}
+
+    /// Mark the bar as finished. Called automatically on drop for impls that
+    /// implement [`Drop`]; provided here for explicit completion semantics.
+    fn finish(&self) {}
+}
+
+/// Object-safe trait for spawning per-operation progress handles.
+///
+/// One [`ProgressReporter`] is shared across an entire command and produces a
+/// new [`ProgressHandle`] for each blob/layer/manifest operation that wants
+/// to report.
+pub trait ProgressReporter: Send + Sync {
+    /// Begin a new progress unit with the given total byte count and label.
+    fn start(&self, total: u64, label: &str) -> Box<dyn ProgressHandle>;
+}
+
+/// A no-op handle for when progress is disabled.
+pub struct NoopHandle;
+
+impl ProgressHandle for NoopHandle {
+    fn inc(&self, _delta: u64) {}
+}
+
+/// Cheap-to-clone shared owner of a [`ProgressReporter`] that can be moved
+/// into spawned tasks. `None` represents "no progress" without forcing
+/// callers to allocate.
+#[derive(Clone, Default)]
+pub struct SharedProgress(Option<Arc<dyn ProgressReporter>>);
+
+impl SharedProgress {
+    pub fn new(reporter: Arc<dyn ProgressReporter>) -> Self {
+        Self(Some(reporter))
+    }
+
+    pub fn none() -> Self {
+        Self(None)
+    }
+
+    /// Borrow the inner reporter as `Option<&dyn ProgressReporter>` for
+    /// passing into the per-blob APIs.
+    pub fn as_ref(&self) -> Option<&dyn ProgressReporter> {
+        self.0.as_deref()
+    }
+}
+
+#[cfg(feature = "progress")]
+mod indicatif_impl {
+    use super::{ProgressHandle, ProgressReporter};
+    use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+    /// `indicatif`-backed implementation of [`ProgressReporter`].
+    ///
+    /// Wraps a [`MultiProgress`] and produces a styled [`ProgressBar`] for
+    /// every operation.
+    pub struct IndicatifReporter {
+        multi: MultiProgress,
+    }
+
+    impl IndicatifReporter {
+        pub fn new(multi: MultiProgress) -> Self {
+            Self { multi }
+        }
+    }
+
+    impl ProgressReporter for IndicatifReporter {
+        fn start(&self, total: u64, label: &str) -> Box<dyn ProgressHandle> {
+            let bar = self.multi.add(ProgressBar::new(total));
+            // The unwrap on the template is a literal known-good template.
+            let style = ProgressStyle::with_template(
+                "{prefix}: [{elapsed_precise}] {bar:40.cyan/blue} {msg} ({binary_bytes:>7}/{binary_total_bytes:7})",
+            )
+            .expect("invariant: progress template literal is valid")
+            .progress_chars("##-");
+            bar.set_style(style);
+            bar.set_prefix(label.to_string());
+            Box::new(IndicatifHandle { bar })
+        }
+    }
+
+    /// Handle wrapping a single [`ProgressBar`].
+    pub struct IndicatifHandle {
+        bar: ProgressBar,
+    }
+
+    impl ProgressHandle for IndicatifHandle {
+        fn inc(&self, delta: u64) {
+            self.bar.inc(delta);
+        }
+
+        fn set_message(&self, message: &str) {
+            self.bar.set_message(message.to_string());
+        }
+
+        fn finish(&self) {
+            self.bar.finish_with_message("done");
+        }
+    }
+
+    impl Drop for IndicatifHandle {
+        fn drop(&mut self) {
+            if !self.bar.is_finished() {
+                self.bar.finish_with_message("done");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "progress")]
+pub use indicatif_impl::{IndicatifHandle, IndicatifReporter};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,13 +12,14 @@ use bytes::Bytes;
 use cfg_if::cfg_if;
 use futures::stream::{Stream, TryStreamExt};
 use home::home_dir;
-use keyring::Entry;
+use keyring_core::Entry;
 use reqwest::Response;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use snafu::{OptionExt, ResultExt, ensure};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use url::Url;
 
 const COMMON_AUTH_FILES: &[&str] = &[".finch/config.json", ".docker/config.json"];
@@ -379,6 +380,18 @@ impl Registry {
     }
 }
 
+/// Initialize the platform-native keyring store on first use.
+///
+/// `keyring` 4.x requires an explicit default credential store. We pick the
+/// OS-native one (Keychain on macOS, Credential Manager on Windows, keyutils
+/// on Linux, etc.) the first time the auth-file fallback path needs it.
+/// Returns true when a store is available; false when initialization fails,
+/// in which case callers should treat the keyring as unavailable.
+fn ensure_keyring_store() -> bool {
+    static INIT: OnceLock<bool> = OnceLock::new();
+    *INIT.get_or_init(|| keyring::use_native_store(false).is_ok())
+}
+
 /// Read a single docker/finch config file and resolve any matching auth
 /// for the given registry base. Returns Some(token) only when the file
 /// produced a token; never overwrites caller state with None.
@@ -393,6 +406,9 @@ async fn read_auth_file(path: &std::path::Path, registry_base: &str) -> Result<O
     };
     if entry.auth.is_none() && entry.identitytoken.is_none() {
         // Fall back to the system keyring (docker-credential-helpers).
+        if !ensure_keyring_store() {
+            return Ok(None);
+        }
         let Ok(keyring_entry) = Entry::new("docker-credential-helpers", registry_base) else {
             return Ok(None);
         };

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -18,13 +18,16 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use snafu::{OptionExt, ResultExt, ensure};
+use std::path::PathBuf;
 use url::Url;
 
 const COMMON_AUTH_FILES: &[&str] = &[".finch/config.json", ".docker/config.json"];
 
 /// Represents a client to a specific OCI registry.
 ///
-/// Most requests will go through this structure.
+/// Most requests will go through this structure. The inner `RegistryClient`
+/// is `Send + Sync + Debug` by virtue of its trait bound, so no `unsafe impl`
+/// is needed here.
 #[derive(Clone, Debug)]
 pub struct Registry {
     /// URI of the registry
@@ -35,28 +38,24 @@ pub struct Registry {
     is_ecr: bool,
 }
 
-unsafe impl Send for Registry {}
-unsafe impl Sync for Registry {}
-
 impl Registry {
     /// Given a uri to a registry create a new registry client and gather
     /// the appropriate authorization.
     pub async fn new(uri: &RegistryUri) -> Result<Self> {
-        // First check our common auth files for an entry
-        let mut token = None;
+        let mut token: Option<Token> = None;
         #[cfg(feature = "aws")]
         let mut is_ecr = false;
-        // If we get here then we may want to try and utilize credential helpers for given registry types
+        // Try AWS credential helpers first when the URI looks like ECR.
         cfg_if! {
             if #[cfg(feature = "aws")] {
                 if uri.base().starts_with("public.ecr.aws") {
                     debug!(target: "registry", "using public ecr");
-                    // Public ecr
                     let sdk_config = aws_config::defaults(BehaviorVersion::latest()).region("us-east-1").load().await;
                     let client = aws_sdk_ecrpublic::Client::new(&sdk_config);
                     let ecr_response = client.get_authorization_token().send()
                         .await
-                        .map_err(|e| { error!("public ecr: {:?}", e); error::Error::Authorization { reason: e.to_string() } })?;
+                        .inspect_err(|e| error!("public ecr: {:?}", e))
+                        .context(error::EcrPublicAuthSnafu)?;
                     trace!(target: "registry", "public ecr authorization response: {:?}", ecr_response);
                     is_ecr = true;
                     token = ecr_response.authorization_data()
@@ -70,60 +69,44 @@ impl Registry {
                     let ecr_response = ecr_client.get_authorization_token()
                         .send()
                         .await
-                        .map_err(|e| error::Error::Authorization { reason: e.to_string() })?;
+                        .context(error::EcrPrivateAuthSnafu)?;
                     trace!(target: "registry", "private ecr authorization response: {:?}", ecr_response);
-                    token = ecr_response.authorization_data()
-                        .first()
-                        .and_then(|x| {
-                            x.authorization_token().map(|y| {
-                                let decoded = base64::engine::general_purpose::STANDARD.decode(y).unwrap();
-                                Token::Basic { username: "AWS".to_string(), password: String::from_utf8_lossy(decoded.as_slice()).strip_prefix("AWS:").unwrap().to_string() }
-                            })
+                    if let Some(authorization_token) = ecr_response.authorization_data().first().and_then(|x| x.authorization_token()) {
+                        let decoded = base64::engine::general_purpose::STANDARD
+                            .decode(authorization_token)
+                            .context(error::AuthBase64DecodeSnafu {
+                                context: "ecr authorization token",
+                            })?;
+                        let decoded_str = std::str::from_utf8(&decoded)
+                            .context(error::AuthUtf8Snafu {
+                                context: "ecr authorization token",
+                            })?;
+                        let (_user, password) = decoded_str
+                            .split_once(':')
+                            .context(error::AuthMissingSeparatorSnafu {
+                                context: "ecr authorization token",
+                            })?;
+                        token = Some(Token::Basic {
+                            username: "AWS".to_string(),
+                            password: password.to_string(),
                         });
+                    }
                 }
             }
         }
-        if token.is_none() {
-            // If a token hasn't been resolved try the keyring
+        // Then try config files in priority order. break on first hit so we
+        // never overwrite an earlier-resolved token with a later None value.
+        if token.is_none()
+            && let Some(home) = home_dir()
+        {
             for file in COMMON_AUTH_FILES {
-                if let Some(path) = home_dir() {
-                    let path = path.join(file);
-                    if path.exists() {
-                        let auth = tokio::fs::read_to_string(path)
-                            .await
-                            .context(error::FileSnafu)?;
-                        let config: DockerConfig =
-                            serde_json::from_str(&auth).context(error::ConfigDeserializeSnafu)?;
-                        if let Some(entry) = config.auths.get(uri.base()) {
-                            // If both the auth and identity token are null then the password is probably stored in the system keychai
-                            if entry.auth.is_none() && entry.identitytoken.is_none() {
-                                if let Ok(entry) =
-                                    Entry::new("docker-credential-helpers", uri.base())
-                                {
-                                    if let Ok(password) = entry.get_password() {
-                                        let decoded = base64::engine::general_purpose::STANDARD
-                                            .decode(password)
-                                            .unwrap();
-                                        let decoded = String::from_utf8_lossy(decoded.as_slice());
-                                        if decoded.contains(':') {
-                                            let (username, password) =
-                                                decoded.split_once(':').unwrap();
-                                            token = Some(Token::Basic {
-                                                username: username.to_string(),
-                                                password: password.to_string(),
-                                            });
-                                        } else {
-                                            token = Some(Token::Bearer(decoded.to_string()));
-                                        }
-                                    } else {
-                                        token = None;
-                                    }
-                                }
-                            } else {
-                                token = Token::parse(entry.clone());
-                            }
-                        }
-                    }
+                let path: PathBuf = home.join(file);
+                if !path.exists() {
+                    continue;
+                }
+                if let Some(found) = read_auth_file(&path, uri.base()).await? {
+                    token = Some(found);
+                    break;
                 }
             }
         }
@@ -151,7 +134,7 @@ impl Registry {
     }
 
     /// Get a ecr correct repository name
-    fn repository_name(&self, repository: &str) -> String {
+    pub(crate) fn repository_name(&self, repository: &str) -> String {
         cfg_if! {
             if #[cfg(feature = "aws")] {
                 if self.is_ecr {
@@ -171,7 +154,7 @@ impl Registry {
 
     // Fetch the catalog of repositories in the registry
     pub async fn catalog(&self) -> crate::Result<Vec<String>> {
-        let response = self.client.clone().catalog(self.url()?).await?;
+        let response = self.client.catalog(self.url()?).await?;
         trace!(target: "registry", "catalog: {:?}", response);
         ensure!(
             response.status().is_success(),
@@ -191,7 +174,6 @@ impl Registry {
         let repository = self.repository_name(repository);
         let response = self
             .client
-            .clone()
             .head_blob(self.url()?, repository, digest.into())
             .await?;
         trace!(target: "registry", "head_blob: {:?}", response);
@@ -210,7 +192,6 @@ impl Registry {
         let repository = self.repository_name(repository);
         let response = self
             .client
-            .clone()
             .get_blob(self.url()?, repository, digest.into())
             .await?;
         trace!(target: "registry", "get_blob: {:?}", response);
@@ -389,7 +370,84 @@ impl Registry {
             .json()
             .await
             .context(error::ResponseDeserializeSnafu)?;
-        trace!(target: "registry", "RESPONSE BODY: {}", serde_json::to_string_pretty(&value).unwrap());
+        if tracing::enabled!(tracing::Level::TRACE)
+            && let Ok(pretty) = serde_json::to_string_pretty(&value)
+        {
+            trace!(target: "registry", "RESPONSE BODY: {}", pretty);
+        }
         serde_json::from_value(value).context(error::BodyDeserializeSnafu)
+    }
+}
+
+/// Read a single docker/finch config file and resolve any matching auth
+/// for the given registry base. Returns Some(token) only when the file
+/// produced a token; never overwrites caller state with None.
+async fn read_auth_file(path: &std::path::Path, registry_base: &str) -> Result<Option<Token>> {
+    let auth = tokio::fs::read_to_string(path)
+        .await
+        .context(error::FileSnafu)?;
+    let config: DockerConfig =
+        serde_json::from_str(&auth).context(error::ConfigDeserializeSnafu)?;
+    let Some(entry) = config.auths.get(registry_base) else {
+        return Ok(None);
+    };
+    if entry.auth.is_none() && entry.identitytoken.is_none() {
+        // Fall back to the system keyring (docker-credential-helpers).
+        let Ok(keyring_entry) = Entry::new("docker-credential-helpers", registry_base) else {
+            return Ok(None);
+        };
+        let Ok(password) = keyring_entry.get_password() else {
+            return Ok(None);
+        };
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&password)
+            .context(error::AuthBase64DecodeSnafu {
+                context: "keyring credential",
+            })?;
+        let decoded_str = std::str::from_utf8(&decoded).context(error::AuthUtf8Snafu {
+            context: "keyring credential",
+        })?;
+        if let Some((username, password)) = decoded_str.split_once(':') {
+            return Ok(Some(Token::Basic {
+                username: username.to_string(),
+                password: password.to_string(),
+            }));
+        }
+        return Ok(Some(Token::Bearer(decoded_str.to_string())));
+    }
+    Token::parse(entry.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_auth_file_ignores_missing_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        tokio::fs::write(&path, r#"{"auths":{"other.io":{"auth":"dXNlcjpwYXNz"}}}"#)
+            .await
+            .unwrap();
+        let res = read_auth_file(&path, "absent.io").await.unwrap();
+        assert!(res.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_auth_file_decodes_basic_auth() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        // base64("user:pass") = "dXNlcjpwYXNz"
+        tokio::fs::write(&path, r#"{"auths":{"present.io":{"auth":"dXNlcjpwYXNz"}}}"#)
+            .await
+            .unwrap();
+        let res = read_auth_file(&path, "present.io").await.unwrap();
+        match res {
+            Some(Token::Basic { username, password }) => {
+                assert_eq!(username, "user");
+                assert_eq!(password, "pass");
+            }
+            other => panic!("expected basic auth, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
Replace all unsafe Send/Sync impls with sound trait-bound types. Introduce a Digest newtype that validates algo:hex and replaces unwrap-based parsing throughout. Make auth parsing return typed errors instead of panicking.

Switch fan-out operations (to_tarball, to_oci, copy, push) from join_all to try_join_all so the first error aborts. Honor registry-returned upload Locations for chunked uploads instead of reformatting URLs, preserving query strings across PATCH/PUT.

Collapse the duplicated _progress API surface into Option<&dyn ProgressReporter>. Rewrite the chunked upload Writer as an explicit state machine with no wake_by_ref; hash and offset advance only after the registry confirms each part. Fix Reader to tick progress per poll and validate size + digest at EOF. Map spawn JoinErrors to a typed Error::Join.

Also: fix layer copy to advance by read_size (was a real bug for small layers), enforce .finch -> .docker -> keyring auth precedence, return Unsupported for lz4 instead of misusing the LZMA decoder, and replace the leaked MultiProgress with an Arc-backed SharedProgress.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
