### PR TITLE
fix(manifest): dispatch on mediaType when fetching manifests

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,7 +25,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR
@@ -50,4 +49,3 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,16 @@ use reqwest::{RequestBuilder, Response};
 use snafu::{OptionExt, ResultExt};
 use url::Url;
 
+/// Accept header sent on manifest requests so the registry returns the
+/// canonical manifest representation rather than an arbitrary default.
+/// Includes both OCI and Docker media types for maximum compatibility.
+pub(crate) const MANIFEST_ACCEPT: &str = concat!(
+    "application/vnd.oci.image.index.v1+json,",
+    "application/vnd.oci.image.manifest.v1+json,",
+    "application/vnd.docker.distribution.manifest.list.v2+json,",
+    "application/vnd.docker.distribution.manifest.v2+json",
+);
+
 /// A trait for a client implementing requests to an OCI registry.
 ///
 /// This is primarily implemented to allow for ease of unit testing this crate.
@@ -233,7 +243,11 @@ impl RegistryClientImpl for SimpleRegistryClient {
             uri.join(&format!("/v2/{}/manifests/{}", repository, reference))
                 .context(error::UrlSnafu)?,
         );
-        self.auth(request).send().await.context(error::RequestSnafu)
+        self.auth(request)
+            .header("Accept", MANIFEST_ACCEPT)
+            .send()
+            .await
+            .context(error::RequestSnafu)
     }
 
     async fn get_manifest(&self, uri: &Url, repository: &str, reference: &str) -> Result<Response> {
@@ -241,7 +255,11 @@ impl RegistryClientImpl for SimpleRegistryClient {
             uri.join(&format!("/v2/{}/manifests/{}", repository, reference))
                 .context(error::UrlSnafu)?,
         );
-        self.auth(request).send().await.context(error::RequestSnafu)
+        self.auth(request)
+            .header("Accept", MANIFEST_ACCEPT)
+            .send()
+            .await
+            .context(error::RequestSnafu)
     }
 
     async fn put_manifest(

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,7 +1,7 @@
 use super::context::Ctx;
 use clap::Parser;
 use ocilot::error;
-use ocilot::index::Index;
+use ocilot::manifest::Manifest;
 use ocilot::uri::Uri;
 use snafu::{OptionExt, ResultExt};
 
@@ -19,12 +19,16 @@ impl Config {
     pub async fn run(&self, _ctx: &Ctx) -> Result<(), error::Error> {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let index = Index::fetch(&uri).await?;
         let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
-        let image = index
-            .fetch_image(&uri, platform)
-            .await?
-            .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
+        // The reference may resolve to either an image index or a single
+        // image manifest; dispatch via `Manifest::fetch` to handle both.
+        let image = match Manifest::fetch(&uri).await? {
+            Manifest::Index(index) => index
+                .fetch_image(&uri, platform)
+                .await?
+                .context(error::ImageNotFoundSnafu { uri: uri.clone() })?,
+            Manifest::Image(image) => image,
+        };
         let config = image.fetch_config(&uri).await?;
         println!(
             "{}",

--- a/src/cmd/copy.rs
+++ b/src/cmd/copy.rs
@@ -6,8 +6,9 @@ use futures::future::try_join_all;
 use ocilot::{
     Result, error,
     image::Image,
-    index::Index,
     layer::Layer,
+    manifest::Manifest,
+    progress::SharedProgress,
     uri::{Reference, Uri},
 };
 use snafu::ResultExt;
@@ -30,75 +31,97 @@ impl Copy {
         source.set_secure(!self.source_insecure);
         let mut target = Uri::new(self.target.as_str()).await?;
         target.set_secure(!self.target_insecure);
-        let index = Index::fetch(&source).await?;
         let progress = ctx.progress();
-        for manifest in index.manifests().iter() {
-            let manifest_uri = Uri::builder()
-                .registry(source.registry().clone())
-                .repository(source.repository())
-                .reference(Reference::from_str(manifest.digest())?)
-                .build();
-            let image = Image::fetch(&manifest_uri, manifest.platform().clone()).await?;
-            // Copy the config over
-            let config_uri = Uri::builder()
-                .registry(target.registry().clone())
-                .repository(target.repository())
-                .reference(Reference::from_str(image.config().digest())?)
-                .build();
+        // The source reference may resolve to either an image index or a
+        // single image manifest. Dispatch via `Manifest::fetch` so a digest
+        // pointing directly at an image is handled correctly.
+        match Manifest::fetch(&source).await? {
+            Manifest::Index(index) => {
+                for manifest in index.manifests().iter() {
+                    let manifest_uri = Uri::builder()
+                        .registry(source.registry().clone())
+                        .repository(source.repository())
+                        .reference(Reference::from_str(manifest.digest())?)
+                        .build();
+                    let image = Image::fetch(&manifest_uri, manifest.platform().clone()).await?;
+                    let target_manifest_uri = Uri::builder()
+                        .registry(target.registry().clone())
+                        .repository(target.repository())
+                        .reference(Reference::from_str(manifest.digest())?)
+                        .build();
+                    copy_image(&source, &target_manifest_uri, &image, &progress).await?;
+                }
+                // Now all images in the index are copied; push the index.
+                index.push(&target).await?;
+            }
+            Manifest::Image(image) => {
+                copy_image(&source, &target, &image, &progress).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Copy a single image (config + layers) from `source` to `target_manifest_uri`.
+async fn copy_image(
+    source: &Uri,
+    target_manifest_uri: &Uri,
+    image: &Image,
+    progress: &SharedProgress,
+) -> Result<()> {
+    // Copy the config blob.
+    let config_uri = Uri::builder()
+        .registry(target_manifest_uri.registry().clone())
+        .repository(target_manifest_uri.repository())
+        .reference(Reference::from_str(image.config().digest())?)
+        .build();
+    let mut writer = Layer::create(
+        &config_uri,
+        image.config().media_type(),
+        image.config().size(),
+        Some(image.config().digest().to_string()),
+        progress.as_ref(),
+    )
+    .await?;
+    if let Some(writer) = writer.as_mut() {
+        let mut reader = image.config().open(source, progress.as_ref()).await?;
+        Layer::copy(&mut reader, writer, image.config().size()).await?;
+        writer.layer().await?;
+    }
+
+    // Copy each layer in parallel.
+    let mut tasks: Vec<JoinHandle<Result<()>>> = Vec::new();
+    for layer in image.layers().iter() {
+        let source_uri = source.clone();
+        let target_uri = target_manifest_uri.clone();
+        let layer = layer.clone();
+        let progress = progress.clone();
+        tasks.push(tokio::spawn(async move {
             let mut writer = Layer::create(
-                &config_uri,
-                image.config().media_type(),
-                image.config().size(),
-                Some(image.config().digest().to_string()),
+                &target_uri,
+                layer.media_type(),
+                layer.size(),
+                Some(layer.digest().to_string()),
                 progress.as_ref(),
             )
             .await?;
             if let Some(writer) = writer.as_mut() {
-                let mut reader = image.config().open(&source, progress.as_ref()).await?;
-                Layer::copy(&mut reader, writer, image.config().size()).await?;
+                let mut reader = layer.open(&source_uri, progress.as_ref()).await?;
+                Layer::copy(&mut reader, writer, layer.size()).await?;
                 writer.layer().await?;
             }
-            // Now we are ready to copy the layers for this image
-            let mut tasks: Vec<JoinHandle<Result<()>>> = Vec::new();
-            for layer in image.layers().iter() {
-                let source_uri = source.clone();
-                let target_uri = target.clone();
-                let layer = layer.clone();
-                let progress = progress.clone();
-                tasks.push(tokio::spawn(async move {
-                    let mut writer = Layer::create(
-                        &target_uri,
-                        layer.media_type(),
-                        layer.size(),
-                        Some(layer.digest().to_string()),
-                        progress.as_ref(),
-                    )
-                    .await?;
-                    if let Some(writer) = writer.as_mut() {
-                        let mut reader = layer.open(&source_uri, progress.as_ref()).await?;
-                        Layer::copy(&mut reader, writer, layer.size()).await?;
-                        writer.layer().await?;
-                    }
-                    Ok(())
-                }));
-            }
-            // try_join_all aborts on first error and reports JoinErrors
-            // through the typed Error::Join variant (#4 + #11).
-            try_join_all(tasks)
-                .await
-                .context(error::JoinSnafu)?
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?;
-            let target_manifest_uri = Uri::builder()
-                .registry(target.registry().clone())
-                .repository(target.repository())
-                .reference(Reference::from_str(manifest.digest())?)
-                .build();
-            image.push(&target_manifest_uri).await?;
-        }
-        // Now all images in index are copied push the index
-        index.push(&target).await?;
-
-        Ok(())
+            Ok(())
+        }));
     }
+    // try_join_all aborts on first error and reports JoinErrors
+    // through the typed Error::Join variant.
+    try_join_all(tasks)
+        .await
+        .context(error::JoinSnafu)?
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+    image.push(target_manifest_uri).await?;
+    Ok(())
 }

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use ocilot::error;
-use ocilot::index::Index;
+use ocilot::manifest::Manifest;
 use ocilot::uri::Uri;
 use snafu::{OptionExt, ResultExt};
 use std::path::PathBuf;
@@ -23,12 +23,16 @@ impl Export {
     pub async fn run(&self, ctx: &mut Ctx) -> Result<(), error::Error> {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let index = Index::fetch(&uri).await?;
         let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
-        let image = index
-            .fetch_image(&uri, platform)
-            .await?
-            .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
+        // The reference may resolve to either an image index or a single
+        // image manifest; dispatch via `Manifest::fetch` to handle both.
+        let image = match Manifest::fetch(&uri).await? {
+            Manifest::Index(index) => index
+                .fetch_image(&uri, platform)
+                .await?
+                .context(error::ImageNotFoundSnafu { uri: uri.clone() })?,
+            Manifest::Image(image) => image,
+        };
 
         let file = tokio::fs::File::create(&self.output)
             .await

--- a/src/cmd/index.rs
+++ b/src/cmd/index.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use ocilot::error;
 use ocilot::layer::Layer;
+use ocilot::manifest::Manifest;
 use ocilot::models::Platform;
 use ocilot::uri::Reference;
 use ocilot::uri::Uri;
@@ -48,7 +49,16 @@ impl GetIndex {
     pub async fn run(&self, _ctx: &Ctx) -> Result<(), ocilot::error::Error> {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let index = Index::fetch(&uri).await?;
+        // `index get` legitimately requires an index; if the reference
+        // resolves to a single image manifest we surface a typed error
+        // rather than the cryptic "missing field 'manifests'" deserialize
+        // failure that used to bubble up.
+        let index = match Manifest::fetch(&uri).await? {
+            Manifest::Index(index) => index,
+            Manifest::Image(_) => {
+                return error::NoIndexSnafu { uri: uri.clone() }.fail();
+            }
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&index).context(ocilot::error::SerializeSnafu)?
@@ -75,25 +85,39 @@ impl AddIndex {
         target.set_secure(!self.insecure);
         let mut source = Uri::new(self.source.as_str()).await?;
         source.set_secure(!self.insecure);
+        // Load (or initialize) the target index. If something exists at the
+        // target reference it must be an index — otherwise overwriting it
+        // with a new index would silently clobber an image manifest.
         let index = if Index::check(&target).await? {
-            Index::fetch(&target).await?
+            match Manifest::fetch(&target).await? {
+                Manifest::Index(index) => index,
+                Manifest::Image(_) => {
+                    return error::NoIndexSnafu {
+                        uri: target.clone(),
+                    }
+                    .fail();
+                }
+            }
         } else {
             Index::new(&[]).await
         };
 
-        // Now load the manifest we want to add
+        // Now load the manifest we want to add.
         let platform: Option<Platform> = self.platform.clone().map(|x| x.parse()).transpose()?;
-        // If a platform is set and reference is a tag we can use an index to find the right
-        // image
+        // If a platform is set and the source is a tag, the source could be
+        // either an index (pick the matching arch) or a single image manifest
+        // (use directly). Dispatch via `Manifest::fetch`.
         let image = if let Some(platform) = platform.as_ref() {
             if matches!(source.reference(), Reference::Tag(..)) {
-                let source_index = Index::fetch(&source).await?;
-                source_index
-                    .fetch_image(&source, Some(platform.clone()))
-                    .await?
-                    .context(error::IndexNoPlatformSnafu {
-                        platform: platform.clone(),
-                    })?
+                match Manifest::fetch(&source).await? {
+                    Manifest::Index(source_index) => source_index
+                        .fetch_image(&source, Some(platform.clone()))
+                        .await?
+                        .context(error::IndexNoPlatformSnafu {
+                            platform: platform.clone(),
+                        })?,
+                    Manifest::Image(image) => image,
+                }
             } else {
                 Image::fetch(&source, Some(platform.clone())).await?
             }

--- a/src/cmd/manifest.rs
+++ b/src/cmd/manifest.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 use ocilot::error;
-use ocilot::index::Index;
+use ocilot::manifest::Manifest as OciManifest;
 use ocilot::models::Platform;
 use ocilot::uri::Uri;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 
 use super::context::Ctx;
 
@@ -23,8 +23,17 @@ impl Manifest {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
         let platform: Option<Platform> = self.platform.clone().map(|x| x.parse()).transpose()?;
-        let index = Index::fetch(&uri).await?;
-        let image = index.fetch_image(&uri, platform).await?;
+
+        // The reference may resolve to either an image index (manifest list)
+        // or an image manifest. Dispatch on `mediaType` so we deserialize
+        // into the right shape rather than blindly assuming an index.
+        let image = match OciManifest::fetch(&uri).await? {
+            OciManifest::Index(index) => index
+                .fetch_image(&uri, platform)
+                .await?
+                .context(error::ImageNotFoundSnafu { uri: uri.clone() })?,
+            OciManifest::Image(image) => image,
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&image).context(error::SerializeSnafu)?

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, ValueEnum};
-use ocilot::index::Index;
+use ocilot::manifest::Manifest;
 use ocilot::uri::Uri;
 use ocilot::{Result, error};
 use snafu::{OptionExt, ResultExt};
@@ -33,22 +33,37 @@ impl Pull {
     pub async fn run(&self, ctx: &mut Ctx) -> Result<()> {
         let mut uri = Uri::new(self.url.as_str()).await?;
         uri.set_secure(!self.insecure);
-        let index = Index::fetch(&uri).await?;
         let platform = self.platform.clone().map(|x| x.parse()).transpose()?;
 
         let output = tokio::fs::File::create(&self.output)
             .await
             .context(error::FileSnafu)?;
         let progress = ctx.progress();
-        match self.format {
-            Format::Tarball => {
-                let image = index
-                    .fetch_image(&uri, platform.clone())
-                    .await?
-                    .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
-                image.to_tarball(&uri, output, progress).await?
-            }
-            Format::Oci => index.to_oci(&uri, platform, output, progress).await?,
+        // The reference may resolve to either an image index or a single
+        // image manifest. Dispatch via `Manifest::fetch` so a digest pointing
+        // directly at an image manifest is handled correctly.
+        match Manifest::fetch(&uri).await? {
+            Manifest::Index(index) => match self.format {
+                Format::Tarball => {
+                    let image = index
+                        .fetch_image(&uri, platform.clone())
+                        .await?
+                        .context(error::ImageNotFoundSnafu { uri: uri.clone() })?;
+                    image.to_tarball(&uri, output, progress).await?
+                }
+                Format::Oci => index.to_oci(&uri, platform, output, progress).await?,
+            },
+            Manifest::Image(image) => match self.format {
+                Format::Tarball => image.to_tarball(&uri, output, progress).await?,
+                Format::Oci => {
+                    return error::UnsupportedSnafu {
+                        reason: format!(
+                            "OCI archive format requires an image index but '{uri}' resolves to a single image manifest"
+                        ),
+                    }
+                    .fail();
+                }
+            },
         }
 
         Ok(())

--- a/src/image.rs
+++ b/src/image.rs
@@ -216,9 +216,7 @@ impl Image {
         }
         // try_join_all aborts on first error and returns the join error
         // properly typed; #4 + #11.
-        let names = try_join_all(tasks)
-            .await
-            .context(error::JoinSnafu)?;
+        let names = try_join_all(tasks).await.context(error::JoinSnafu)?;
         for name in names {
             manifest.layers.push(name?);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod image;
 pub mod index;
 /// Layer read/write operations.
 pub mod layer;
+/// Typed manifest dispatch (index vs image).
+pub mod manifest;
 /// OCI specification model types.
 pub mod models;
 /// Optional progress reporting trait.

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,77 @@
+//! Typed dispatch over OCI manifest documents.
+//!
+//! A digest reference can resolve to either an [`Index`] (image index /
+//! manifest list) or an [`Image`] (image manifest). [`Manifest::fetch`]
+//! inspects the `mediaType` field of the response and deserializes into the
+//! correct variant rather than blindly assuming an index.
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::image::Image;
+use crate::index::Index;
+use crate::models::MediaType;
+use crate::uri::Uri;
+use crate::{Result, error};
+
+/// A manifest document fetched from a registry.
+///
+/// Use [`Manifest::fetch`] when the caller does not know up front whether the
+/// target reference points at an index or a single-image manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Manifest {
+    /// An image index / manifest list.
+    Index(Index),
+    /// A single image manifest.
+    Image(Image),
+}
+
+impl Manifest {
+    /// Fetch a manifest from a registry, dispatching on the `mediaType` field
+    /// of the response so the correct variant is returned.
+    ///
+    /// Falls back to [`error::BodyDeserializeSnafu`] when the response is
+    /// missing `mediaType` or contains an unrecognized value.
+    pub async fn fetch(uri: &Uri) -> Result<Self> {
+        let value = uri
+            .registry()
+            .fetch_manifest_value(uri.repository(), uri.reference().to_string().as_str())
+            .await?;
+        let media_type: Option<MediaType> = value
+            .get("mediaType")
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        match media_type {
+            Some(MediaType::ImageIndex) | Some(MediaType::DockerManifestList) => {
+                let index = serde_json::from_value(value).context(error::BodyDeserializeSnafu)?;
+                Ok(Manifest::Index(index))
+            }
+            Some(MediaType::Manifest) | Some(MediaType::DockerManifest) => {
+                let image = serde_json::from_value(value).context(error::BodyDeserializeSnafu)?;
+                Ok(Manifest::Image(image))
+            }
+            // For anything else (including missing mediaType) try the index
+            // shape first to preserve historical behaviour, then fall back to
+            // the image shape so legacy / non-conforming registries still work.
+            _ => {
+                if value.get("manifests").is_some() {
+                    let index =
+                        serde_json::from_value(value).context(error::BodyDeserializeSnafu)?;
+                    Ok(Manifest::Index(index))
+                } else {
+                    let image =
+                        serde_json::from_value(value).context(error::BodyDeserializeSnafu)?;
+                    Ok(Manifest::Image(image))
+                }
+            }
+        }
+    }
+
+    /// The media type of the underlying manifest.
+    pub fn media_type(&self) -> &MediaType {
+        match self {
+            Manifest::Index(i) => i.media_type(),
+            Manifest::Image(i) => i.media_type(),
+        }
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -190,11 +190,12 @@ impl FromStr for Platform {
     type Err = crate::error::Error;
 
     fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
-        let (os, architecture) = value.split_once('/').context(
-            crate::error::InvalidPlatformFormatSnafu {
-                value: value.to_string(),
-            },
-        )?;
+        let (os, architecture) =
+            value
+                .split_once('/')
+                .context(crate::error::InvalidPlatformFormatSnafu {
+                    value: value.to_string(),
+                })?;
         snafu::ensure!(
             !os.is_empty() && !architecture.is_empty(),
             crate::error::InvalidPlatformEmptySnafu {
@@ -423,10 +424,9 @@ impl Token {
             .context(crate::error::AuthBase64DecodeSnafu {
                 context: "docker auth",
             })?;
-        let decoded =
-            std::str::from_utf8(&decoded).context(crate::error::AuthUtf8Snafu {
-                context: "docker auth",
-            })?;
+        let decoded = std::str::from_utf8(&decoded).context(crate::error::AuthUtf8Snafu {
+            context: "docker auth",
+        })?;
         let (username, password) =
             decoded
                 .split_once(':')

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -254,6 +254,20 @@ impl Registry {
     where
         T: DeserializeOwned,
     {
+        let value = self.fetch_manifest_value(repository, reference).await?;
+        serde_json::from_value(value).context(error::BodyDeserializeSnafu)
+    }
+
+    /// Fetch a manifest from the registry as a raw [`serde_json::Value`].
+    ///
+    /// This is useful for callers that need to inspect the `mediaType` field
+    /// before deciding how to deserialize the manifest (e.g. an [`Index`]
+    /// vs. an [`Image`]).
+    pub(crate) async fn fetch_manifest_value(
+        &self,
+        repository: &str,
+        reference: &str,
+    ) -> Result<serde_json::Value> {
         let repository = self.repository_name(repository);
         let response = self
             .client
@@ -269,7 +283,16 @@ impl Registry {
                     .context(error::ErrorDeserializeSnafu)?
             }
         );
-        Self::body(response).await
+        let value: serde_json::Value = response
+            .json()
+            .await
+            .context(error::ResponseDeserializeSnafu)?;
+        if tracing::enabled!(tracing::Level::TRACE)
+            && let Ok(pretty) = serde_json::to_string_pretty(&value)
+        {
+            trace!(target: "registry", "RESPONSE BODY: {}", pretty);
+        }
+        Ok(value)
     }
 
     /// Push a manifest to the oci registtry


### PR DESCRIPTION
Commands that took a digest reference (e.g. `ocilot manifest repo@sha256:...`) blindly deserialized the registry response as an `Index`, failing with `missing field 'manifests'` whenever the digest pointed directly at an image manifest rather than an index.

Introduce a typed `Manifest` enum (`Index`/`Image`) with a `Manifest::fetch` dispatcher that inspects the response's `mediaType` field (with a `manifests`-field fallback for non-conforming registries) and deserializes into the correct variant. Migrate every call site that previously assumed an index:

- manifest, pull, export, config: handle both variants so digest references to single-image manifests work end to end.
- copy: factor a `copy_image` helper used in both branches; for a single-image source copy and push that one image without synthesizing an enclosing index.
- index get: surface a typed `NoIndex` error when the reference resolves to an image instead of leaking a deserialize failure.
- index add: require the target to be an index (or absent), and let the source tag fall back to a single-image manifest.
- pull --format oci against a single image returns a typed `Unsupported` error (OCI archives require an index).

Also send a proper `Accept` header on manifest GET/HEAD so registries return the canonical representation, and expose
`Registry::fetch_manifest_value` (pub(crate)) as the building block.

Closes #2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
